### PR TITLE
Fix peer review issues: filename collision, settings persistence, are…

### DIFF
--- a/Shotter/Sources/Capture/AreaSelectorWindow.swift
+++ b/Shotter/Sources/Capture/AreaSelectorWindow.swift
@@ -82,30 +82,35 @@ class AreaSelectionView: NSView {
     override var acceptsFirstResponder: Bool { true }
     
     override func draw(_ dirtyRect: NSRect) {
-        // Semi-transparent overlay
-        NSColor.black.withAlphaComponent(0.3).setFill()
-        dirtyRect.fill()
-        
         // Draw selection rectangle if selecting
         if let start = selectionStart, let end = selectionEnd {
             let selectionRect = rectFromPoints(start, end)
-            
-            // Clear the selection area (make it transparent)
-            NSColor.clear.setFill()
-            selectionRect.fill()
-            
-            // Draw border
+
+            // Create a path that covers the entire view but excludes the selection
+            let overlayPath = NSBezierPath(rect: bounds)
+            overlayPath.append(NSBezierPath(rect: selectionRect).reversed)
+            overlayPath.windingRule = .evenOdd
+
+            // Fill the overlay (everything except selection)
+            NSColor.black.withAlphaComponent(0.3).setFill()
+            overlayPath.fill()
+
+            // Draw border around selection
             NSColor.white.setStroke()
-            let path = NSBezierPath(rect: selectionRect)
-            path.lineWidth = 2
-            path.stroke()
-            
+            let borderPath = NSBezierPath(rect: selectionRect)
+            borderPath.lineWidth = 2
+            borderPath.stroke()
+
             // Draw dashed inner border
             NSColor.white.withAlphaComponent(0.5).setStroke()
             let dashPath = NSBezierPath(rect: selectionRect.insetBy(dx: 1, dy: 1))
             dashPath.lineWidth = 1
             dashPath.setLineDash([4, 4], count: 2, phase: 0)
             dashPath.stroke()
+        } else {
+            // No selection yet - fill entire view with dim overlay
+            NSColor.black.withAlphaComponent(0.3).setFill()
+            bounds.fill()
         }
     }
     

--- a/Shotter/Sources/Hotkeys/HotkeyManager.swift
+++ b/Shotter/Sources/Hotkeys/HotkeyManager.swift
@@ -64,22 +64,31 @@ class HotkeyManager {
     }
     
     private func handleEvent(proxy: CGEventTapProxy, type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
+        // Handle tap being disabled by macOS (timeout or user input)
+        if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+            logger.warning("Event tap was disabled by macOS, re-enabling...")
+            if let tap = eventTap {
+                CGEvent.tapEnable(tap: tap, enable: true)
+            }
+            return Unmanaged.passRetained(event)
+        }
+
         guard type == .keyDown else {
             return Unmanaged.passRetained(event)
         }
-        
+
         let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
         let flags = event.flags
-        
+
         // Check for Command + Shift modifier
         let hasCommandShift = flags.contains([.maskCommand, .maskShift]) &&
                              !flags.contains(.maskControl) &&
                              !flags.contains(.maskAlternate)
-        
+
         guard hasCommandShift else {
             return Unmanaged.passRetained(event)
         }
-        
+
         // Key code 20 = "3", Key code 21 = "4"
         switch keyCode {
         case 20: // ⌘⇧3 - Fullscreen
@@ -87,13 +96,13 @@ class HotkeyManager {
                 self.onFullscreen()
             }
             return nil // Consume the event
-            
+
         case 21: // ⌘⇧4 - Area
             DispatchQueue.main.async {
                 self.onArea()
             }
             return nil // Consume the event
-            
+
         default:
             return Unmanaged.passRetained(event)
         }

--- a/Shotter/Sources/Overlay/OverlayController.swift
+++ b/Shotter/Sources/Overlay/OverlayController.swift
@@ -39,12 +39,12 @@ class OverlayController {
     private func startDismissTimer() {
         dismissTimer?.invalidate()
         let delay = PreferencesManager.shared.overlayAutoDismissDelay
-        
-        // Don't create timer if delay is infinite (never auto-dismiss)
-        guard delay.isFinite else {
+
+        // Don't create timer if delay is negative (never auto-dismiss)
+        guard delay > 0 else {
             return
         }
-        
+
         dismissTimer = Timer.scheduledTimer(withTimeInterval: delay, repeats: false) { [weak self] _ in
             self?.dismissOverlay()
         }

--- a/Shotter/Sources/Preferences/PreferencesManager.swift
+++ b/Shotter/Sources/Preferences/PreferencesManager.swift
@@ -46,9 +46,15 @@ class PreferencesManager: ObservableObject {
             saveLocation = picturesURL.appendingPathComponent("Shotter")
         }
         
-        // Load overlay delay
+        // Load overlay delay (-1 means never, 0 means not set)
         let delay = defaults.double(forKey: Keys.overlayAutoDismissDelay)
-        overlayAutoDismissDelay = delay > 0 ? delay : 5.0
+        if delay < 0 {
+            overlayAutoDismissDelay = -1.0  // Never auto-dismiss
+        } else if delay > 0 {
+            overlayAutoDismissDelay = delay
+        } else {
+            overlayAutoDismissDelay = 5.0   // Default
+        }
         
         // Load launch at login
         launchAtLogin = defaults.bool(forKey: Keys.launchAtLogin)

--- a/Shotter/Sources/Preferences/PreferencesView.swift
+++ b/Shotter/Sources/Preferences/PreferencesView.swift
@@ -25,7 +25,7 @@ struct PreferencesView: View {
                         Text("3 seconds").tag(3.0)
                         Text("5 seconds").tag(5.0)
                         Text("10 seconds").tag(10.0)
-                        Text("Never").tag(Double.infinity)
+                        Text("Never").tag(-1.0)
                     }
                     .frame(width: 120)
                 }

--- a/Shotter/Sources/Utils/FileNaming.swift
+++ b/Shotter/Sources/Utils/FileNaming.swift
@@ -3,7 +3,7 @@ import Foundation
 struct FileNaming {
     static func generateFilename(extension ext: String = "png") -> String {
         let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd-HHmmss"
+        formatter.dateFormat = "yyyy-MM-dd-HHmmss-SSS"
         let timestamp = formatter.string(from: Date())
         return "Shotter-\(timestamp).\(ext)"
     }

--- a/Shotter/Sources/Utils/Permissions.swift
+++ b/Shotter/Sources/Utils/Permissions.swift
@@ -5,33 +5,34 @@ import os.log
 private let logger = Logger(subsystem: "com.densign.shotter", category: "Permissions")
 
 struct Permissions {
-    
+
     // MARK: - Cached State
-    
+
     private static var cachedScreenRecording: Bool?
     private static var cachedAccessibility: Bool?
-    private static var lastCheckTime: Date?
+    private static var lastScreenRecordingCheck: Date?
+    private static var lastAccessibilityCheck: Date?
     private static let cacheInterval: TimeInterval = 30 // Refresh every 30 seconds
-    
+
     // MARK: - Screen Recording
-    
+
     static func checkScreenRecording() async -> Bool {
         // Return cached value if recent
         if let cached = cachedScreenRecording,
-           let lastCheck = lastCheckTime,
+           let lastCheck = lastScreenRecordingCheck,
            Date().timeIntervalSince(lastCheck) < cacheInterval {
             return cached
         }
-        
+
         do {
             // Attempting to get shareable content will trigger permission prompt if needed
             _ = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: true)
             cachedScreenRecording = true
-            lastCheckTime = Date()
+            lastScreenRecordingCheck = Date()
             return true
         } catch {
             cachedScreenRecording = false
-            lastCheckTime = Date()
+            lastScreenRecordingCheck = Date()
             return false
         }
     }
@@ -53,16 +54,16 @@ struct Permissions {
     static func checkAccessibility() -> Bool {
         // Return cached value if recent
         if let cached = cachedAccessibility,
-           let lastCheck = lastCheckTime,
+           let lastCheck = lastAccessibilityCheck,
            Date().timeIntervalSince(lastCheck) < cacheInterval {
             return cached
         }
-        
+
         // Check if we have accessibility permissions
         let options: NSDictionary = [kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: false]
         let result = AXIsProcessTrustedWithOptions(options)
         cachedAccessibility = result
-        lastCheckTime = Date()
+        lastAccessibilityCheck = Date()
         return result
     }
     
@@ -85,6 +86,7 @@ struct Permissions {
     static func invalidateCache() {
         cachedScreenRecording = nil
         cachedAccessibility = nil
-        lastCheckTime = nil
+        lastScreenRecordingCheck = nil
+        lastAccessibilityCheck = nil
     }
 }


### PR DESCRIPTION
…a selector visibility

- Add milliseconds to filename timestamp to prevent same-second overwrites
- Use -1 sentinel instead of Double.infinity for "Never" auto-dismiss (fixes persistence)
- Fix area selection overlay using even-odd winding path (selection area now visible)
- Split permission cache timestamps to prevent cross-contamination
- Handle event tap timeout/disable by re-enabling automatically