### PR TITLE
Add file drag from overlay thumbnail

### DIFF
--- a/Shotter/Sources/Overlay/OverlayController.swift
+++ b/Shotter/Sources/Overlay/OverlayController.swift
@@ -90,9 +90,23 @@ class OverlayController {
     }
 }
 
-class OverlayWindow: NSPanel {
+class OverlayWindow: NSPanel, NSDraggingSource, NSFilePromiseProviderDelegate {
     private var hostingView: NSHostingView<OverlayView>?
-    
+
+    // Drag state
+    private var image: NSImage
+    private var savedURL: URL?
+    private var onPauseDismiss: () -> Void
+    private var onResumeDismiss: () -> Void
+    private var onDragSuccess: () -> Void
+    private var isDragging = false
+    private var mouseDownLocation: NSPoint?
+    private var currentPromiseFilename: String?
+
+    // Button exclusion zones (top-right action bar, top-left close button)
+    private let actionBarRect: NSRect
+    private let closeButtonRect: NSRect
+
     init(
         image: NSImage,
         savedURL: URL?,
@@ -104,6 +118,28 @@ class OverlayWindow: NSPanel {
         onDragSuccess: @escaping () -> Void,
         onDismiss: @escaping () -> Void
     ) {
+        self.image = image
+        self.savedURL = savedURL
+        self.onPauseDismiss = onPauseDismiss
+        self.onResumeDismiss = onResumeDismiss
+        self.onDragSuccess = onDragSuccess
+
+        let overlayWidth = OverlayLayout.overlayWidth
+        let overlayHeight = OverlayLayout.overlayHeight
+
+        // Define button exclusion zones (in window coordinates, origin bottom-left)
+        // Action bar: top-right corner
+        let actionBarWidth: CGFloat = 50
+        let actionBarHeight: CGFloat = 120
+        self.actionBarRect = NSRect(
+            x: overlayWidth - actionBarWidth - OverlayLayout.actionBarOuterPadding,
+            y: overlayHeight - actionBarHeight - OverlayLayout.actionBarOuterPadding,
+            width: actionBarWidth,
+            height: actionBarHeight
+        )
+        // Close button: top-left corner
+        self.closeButtonRect = NSRect(x: 0, y: overlayHeight - 40, width: 40, height: 40)
+
         // Fixed size container; position above dock using visibleFrame
         guard let screen = NSScreen.main else {
             super.init(
@@ -115,21 +151,16 @@ class OverlayWindow: NSPanel {
             return
         }
 
-        let overlayWidth = OverlayLayout.overlayWidth
-        let overlayHeight = OverlayLayout.overlayHeight
         let padding: CGFloat = 20
 
         // visibleFrame excludes dock and menu bar
         let visibleFrame = screen.visibleFrame
 
         // Check dock orientation from system preferences.
-        // When dock is on left with auto-hide, visibleFrame.minX may be 0,
-        // but dock can reappear and cover the overlay. Always reserve space.
         let dockOrientation = UserDefaults.standard.persistentDomain(forName: "com.apple.dock")?["orientation"] as? String ?? "bottom"
         let dockOnLeft = dockOrientation == "left"
-        let dockReserve: CGFloat = 70  // Typical dock width
+        let dockReserve: CGFloat = 70
 
-        // When dock is on left, use dockReserve as total offset (no extra padding)
         let xOffset = dockOnLeft ? max(visibleFrame.minX + padding, dockReserve) : visibleFrame.minX + padding
 
         let frame = NSRect(
@@ -138,7 +169,7 @@ class OverlayWindow: NSPanel {
             width: overlayWidth,
             height: overlayHeight
         )
-        
+
         super.init(
             contentRect: frame,
             styleMask: [.borderless, .nonactivatingPanel, .hudWindow],
@@ -154,32 +185,181 @@ class OverlayWindow: NSPanel {
         self.hasShadow = true
         self.isMovableByWindowBackground = false
         self.hidesOnDeactivate = false
+        self.ignoresMouseEvents = false
+        self.acceptsMouseMovedEvents = true
         self.contentMinSize = NSSize(width: overlayWidth, height: overlayHeight)
         self.contentMaxSize = NSSize(width: overlayWidth, height: overlayHeight)
-        
+
         // Create SwiftUI view
         let overlayView = OverlayView(
             image: image,
-            savedURL: savedURL,
             onCopy: onCopy,
             onSave: onSave,
             onAnnotate: onAnnotate,
             onPauseDismiss: onPauseDismiss,
             onResumeDismiss: onResumeDismiss,
-            onDragSuccess: onDragSuccess,
             onDismiss: onDismiss
         )
-        
+
         hostingView = NSHostingView(rootView: overlayView)
         hostingView?.wantsLayer = true
         hostingView?.layer?.backgroundColor = NSColor.clear.cgColor
         hostingView?.frame = NSRect(x: 0, y: 0, width: overlayWidth, height: overlayHeight)
         self.contentView = hostingView
     }
-    
+
+    // Allow the panel to become key to receive mouse events properly
+    override var canBecomeKey: Bool { true }
+
+    // MARK: - Mouse handling for drag
+
+    override func sendEvent(_ event: NSEvent) {
+        switch event.type {
+        case .leftMouseDown:
+            let locationInWindow = event.locationInWindow
+
+            // If click is in button areas, let SwiftUI handle it
+            if actionBarRect.contains(locationInWindow) || closeButtonRect.contains(locationInWindow) {
+                super.sendEvent(event)
+                return
+            }
+
+            // Otherwise, track for potential drag
+            mouseDownLocation = locationInWindow
+            isDragging = false
+
+        case .leftMouseDragged:
+            guard let startLocation = mouseDownLocation else {
+                super.sendEvent(event)
+                return
+            }
+
+            // Check if we've dragged enough to start
+            let currentLocation = event.locationInWindow
+            let dx = currentLocation.x - startLocation.x
+            let dy = currentLocation.y - startLocation.y
+            let distance = sqrt(dx * dx + dy * dy)
+
+            if !isDragging && distance > 3 {
+                isDragging = true
+                beginFileDrag(with: event)
+            }
+            return // Don't pass drag events to SwiftUI
+
+        case .leftMouseUp:
+            mouseDownLocation = nil
+            if isDragging {
+                isDragging = false
+                return
+            }
+
+        default:
+            break
+        }
+
+        super.sendEvent(event)
+    }
+
+    private func beginFileDrag(with event: NSEvent) {
+        onPauseDismiss()
+
+        // Gray out the overlay while dragging
+        self.alphaValue = 0.5
+
+        let provider = NSFilePromiseProvider(fileType: UTType.png.identifier, delegate: self)
+        currentPromiseFilename = savedURL?.lastPathComponent ?? FileNaming.generateFilename(extension: "png")
+
+        let draggingItem = NSDraggingItem(pasteboardWriter: provider)
+
+        // Create a smaller drag image (like CleanShot)
+        let dragImageSize = NSSize(width: 120, height: 80)
+        let dragImage = NSImage(size: dragImageSize)
+        dragImage.lockFocus()
+        image.draw(in: NSRect(origin: .zero, size: dragImageSize),
+                   from: NSRect(origin: .zero, size: image.size),
+                   operation: .copy, fraction: 0.9)
+        dragImage.unlockFocus()
+
+        // Position drag image centered on mouse
+        let mouseLocation = event.locationInWindow
+        let dragFrame = NSRect(
+            x: mouseLocation.x - dragImageSize.width / 2,
+            y: mouseLocation.y - dragImageSize.height / 2,
+            width: dragImageSize.width,
+            height: dragImageSize.height
+        )
+        draggingItem.setDraggingFrame(dragFrame, contents: dragImage)
+
+        contentView?.beginDraggingSession(with: [draggingItem], event: event, source: self)
+    }
+
+    // MARK: - NSDraggingSource
+
+    func draggingSession(_ session: NSDraggingSession, sourceOperationMaskFor context: NSDraggingContext) -> NSDragOperation {
+        .copy
+    }
+
+    func draggingSession(_ session: NSDraggingSession, endedAt screenPoint: NSPoint, operation: NSDragOperation) {
+        // Restore opacity
+        self.alphaValue = 1.0
+
+        if operation != [] {
+            onDragSuccess()
+        } else {
+            onResumeDismiss()
+        }
+    }
+
+    // MARK: - NSFilePromiseProviderDelegate
+
+    func filePromiseProvider(_ filePromiseProvider: NSFilePromiseProvider, fileNameForType fileType: String) -> String {
+        currentPromiseFilename ?? savedURL?.lastPathComponent ?? FileNaming.generateFilename(extension: "png")
+    }
+
+    func filePromiseProvider(
+        _ filePromiseProvider: NSFilePromiseProvider,
+        writePromiseTo url: URL,
+        completionHandler: @escaping (Error?) -> Void
+    ) {
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            guard let self = self else {
+                completionHandler(nil)
+                return
+            }
+            do {
+                try self.writePromise(to: url)
+                completionHandler(nil)
+            } catch {
+                completionHandler(error)
+            }
+        }
+    }
+
+    private func writePromise(to destinationURL: URL) throws {
+        let fileManager = FileManager.default
+
+        if let savedURL = savedURL, fileManager.fileExists(atPath: savedURL.path) {
+            if fileManager.fileExists(atPath: destinationURL.path) {
+                try fileManager.removeItem(at: destinationURL)
+            }
+            try fileManager.copyItem(at: savedURL, to: destinationURL)
+            return
+        }
+
+        // Fall back to converting image to PNG
+        guard let tiffData = image.tiffRepresentation,
+              let bitmap = NSBitmapImageRep(data: tiffData),
+              let pngData = bitmap.representation(using: .png, properties: [:]) else {
+            return
+        }
+        try pngData.write(to: destinationURL, options: .atomic)
+    }
+
+    // MARK: - Window lifecycle
+
     func show() {
         self.orderFrontRegardless()
-        
+
         // Animate in
         self.alphaValue = 0
         NSAnimationContext.runAnimationGroup { context in
@@ -187,7 +367,7 @@ class OverlayWindow: NSPanel {
             self.animator().alphaValue = 1
         }
     }
-    
+
     override func close() {
         // Animate out
         NSAnimationContext.runAnimationGroup({ context in
@@ -197,9 +377,8 @@ class OverlayWindow: NSPanel {
             super.close()
         })
     }
-    
+
     func flashCopySuccess() {
-        // Flash the window briefly to indicate success
         NSAnimationContext.runAnimationGroup({ context in
             context.duration = 0.1
             self.animator().alphaValue = 0.5
@@ -214,261 +393,57 @@ class OverlayWindow: NSPanel {
 
 struct OverlayView: View {
     let image: NSImage
-    let savedURL: URL?
     let onCopy: () -> Void
     let onSave: () -> Void
     let onAnnotate: () -> Void
     let onPauseDismiss: () -> Void
     let onResumeDismiss: () -> Void
-    let onDragSuccess: () -> Void
     let onDismiss: () -> Void
 
     @State private var isHovering = false
-    @State private var isDragging = false
 
     var body: some View {
         // Image fills the fixed container (crops if needed), buttons anchor to image edges
-        ZStack {
-            OverlayDragSourceView(
-                image: image,
-                savedURL: savedURL,
-                onDragStart: {
-                    isDragging = true
-                    onPauseDismiss()
-                },
-                onDragCancel: {
-                    isDragging = false
-                    if !isHovering {
-                        onResumeDismiss()
-                    }
-                },
-                onDropComplete: { success in
-                    isDragging = false
-                    if success {
-                        onDragSuccess()
-                    } else if !isHovering {
-                        onResumeDismiss()
-                    }
-                }
-            )
+        Image(nsImage: image)
+            .resizable()
+            .aspectRatio(contentMode: .fill)
             .frame(width: OverlayLayout.overlayWidth, height: OverlayLayout.overlayHeight)
-
-            Image(nsImage: image)
-                .resizable()
-                .aspectRatio(contentMode: .fill)
-                .frame(width: OverlayLayout.overlayWidth, height: OverlayLayout.overlayHeight)
-                .cornerRadius(10)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 10)
-                        .stroke(Color.white.opacity(0.2), lineWidth: 1)
-                )
-                .allowsHitTesting(false)
-        }
-        .frame(width: OverlayLayout.overlayWidth, height: OverlayLayout.overlayHeight)
-        .overlay(alignment: .topTrailing) {
-            // Floating action bar (top-right, inside image)
-            VStack(spacing: OverlayLayout.actionButtonSpacing) {
-                OverlayActionButton(systemName: "doc.on.doc", action: onCopy)
-                    .help("Copy")
-                OverlayActionButton(systemName: "folder", action: onSave, disabled: savedURL == nil)
-                    .help("Show in Finder")
-                OverlayActionButton(systemName: "pencil.tip.crop.circle", action: onAnnotate)
-                    .help("Annotate")
-            }
-            .padding(OverlayLayout.actionBarInnerPadding)
-            .background(ActiveVisualEffectView(material: .hudWindow))
-            .cornerRadius(8)
-            .padding(OverlayLayout.actionBarOuterPadding)
-            .opacity(isHovering ? 1 : 0.7)
-        }
-        .overlay(alignment: .topLeading) {
-            // Close button (top-left corner, inside image)
-            Button(action: onDismiss) {
-                Image(systemName: "xmark.circle.fill")
-                    .font(.system(size: 18))
-                    .foregroundStyle(.white.opacity(0.8))
-                    .background(Circle().fill(Color.black.opacity(0.5)))
-            }
-            .buttonStyle(.plain)
-            .padding(10)
-            .opacity(isHovering ? 1 : 0.6)
-        }
-        .shadow(radius: 8)
-        .onHover { hovering in
-            withAnimation(.easeInOut(duration: 0.15)) { isHovering = hovering }
-            if hovering {
-                onPauseDismiss()
-            } else if !isDragging {
-                onResumeDismiss()
-            }
-        }
-    }
-}
-
-private struct OverlayDragSourceView: NSViewRepresentable {
-    let image: NSImage
-    let savedURL: URL?
-    let onDragStart: () -> Void
-    let onDragCancel: () -> Void
-    let onDropComplete: (Bool) -> Void
-
-    func makeNSView(context: Context) -> OverlayDragSourceNSView {
-        OverlayDragSourceNSView(
-            image: image,
-            savedURL: savedURL,
-            onDragStart: onDragStart,
-            onDragCancel: onDragCancel,
-            onDropComplete: onDropComplete
-        )
-    }
-
-    func updateNSView(_ nsView: OverlayDragSourceNSView, context: Context) {
-        nsView.image = image
-        nsView.savedURL = savedURL
-        nsView.onDragStart = onDragStart
-        nsView.onDragCancel = onDragCancel
-        nsView.onDropComplete = onDropComplete
-    }
-}
-
-private final class OverlayDragSourceNSView: NSView, NSDraggingSource, NSFilePromiseProviderDelegate {
-    var image: NSImage
-    var savedURL: URL?
-    var onDragStart: (() -> Void)?
-    var onDragCancel: (() -> Void)?
-    var onDropComplete: ((Bool) -> Void)?
-
-    private var isDraggingSession = false
-    private var currentPromiseFilename: String?
-
-    init(
-        image: NSImage,
-        savedURL: URL?,
-        onDragStart: @escaping () -> Void,
-        onDragCancel: @escaping () -> Void,
-        onDropComplete: @escaping (Bool) -> Void
-    ) {
-        self.image = image
-        self.savedURL = savedURL
-        self.onDragStart = onDragStart
-        self.onDragCancel = onDragCancel
-        self.onDropComplete = onDropComplete
-        super.init(frame: .zero)
-    }
-
-    required init?(coder: NSCoder) {
-        return nil
-    }
-
-    override func mouseDown(with event: NSEvent) {
-        isDraggingSession = false
-        currentPromiseFilename = nil
-        super.mouseDown(with: event)
-    }
-
-    override func mouseDragged(with event: NSEvent) {
-        guard !isDraggingSession else { return }
-        isDraggingSession = true
-        beginFileDrag(with: event)
-    }
-
-    func draggingSession(_ session: NSDraggingSession, sourceOperationMaskFor context: NSDraggingContext) -> NSDragOperation {
-        .copy
-    }
-
-    func draggingSession(_ session: NSDraggingSession, endedAt screenPoint: NSPoint, operation: NSDragOperation) {
-        if operation == [] {
-            onDragCancel?()
-        }
-        isDraggingSession = false
-    }
-
-    func filePromiseProvider(_ filePromiseProvider: NSFilePromiseProvider, fileNameForType fileType: String) -> String {
-        currentPromiseFilename ?? savedURL?.lastPathComponent ?? FileNaming.generateFilename(extension: "png")
-    }
-
-    func filePromiseProvider(
-        _ filePromiseProvider: NSFilePromiseProvider,
-        writePromiseTo url: URL,
-        completionHandler: @escaping (Error?) -> Void
-    ) {
-        DispatchQueue.global(qos: .userInitiated).async {
-            do {
-                let filename = self.currentPromiseFilename
-                    ?? self.savedURL?.lastPathComponent
-                    ?? FileNaming.generateFilename(extension: "png")
-                let destinationURL = url.appendingPathComponent(filename)
-                try self.writePromise(to: destinationURL)
-                completionHandler(nil)
-                DispatchQueue.main.async {
-                    self.onDropComplete?(true)
+            .cornerRadius(10)
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(Color.white.opacity(0.2), lineWidth: 1)
+            )
+            .allowsHitTesting(false)
+            .frame(width: OverlayLayout.overlayWidth, height: OverlayLayout.overlayHeight)
+            .overlay(alignment: .topTrailing) {
+                // Floating action bar (top-right, inside image)
+                VStack(spacing: OverlayLayout.actionButtonSpacing) {
+                    OverlayActionButton(systemName: "doc.on.doc", action: onCopy)
+                        .help("Copy")
+                    OverlayActionButton(systemName: "folder", action: onSave)
+                        .help("Show in Finder")
+                    OverlayActionButton(systemName: "pencil.tip.crop.circle", action: onAnnotate)
+                        .help("Annotate")
                 }
-            } catch {
-                completionHandler(error)
-                DispatchQueue.main.async {
-                    self.onDropComplete?(false)
+                .padding(OverlayLayout.actionBarInnerPadding)
+                .background(ActiveVisualEffectView(material: .hudWindow))
+                .cornerRadius(8)
+                .padding(OverlayLayout.actionBarOuterPadding)
+                .opacity(isHovering ? 1 : 0.7)
+            }
+            .overlay(alignment: .topLeading) {
+                // Close button (top-left corner, inside image)
+                Button(action: onDismiss) {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 18))
+                        .foregroundStyle(.white.opacity(0.8))
+                        .background(Circle().fill(Color.black.opacity(0.5)))
                 }
+                .buttonStyle(.plain)
+                .padding(10)
+                .opacity(isHovering ? 1 : 0.6)
             }
-        }
-    }
-
-    private func beginFileDrag(with event: NSEvent) {
-        onDragStart?()
-
-        let provider = NSFilePromiseProvider(fileType: UTType.png.identifier, delegate: self)
-        currentPromiseFilename = savedURL?.lastPathComponent ?? FileNaming.generateFilename(extension: "png")
-
-        let draggingItem = NSDraggingItem(pasteboardWriter: provider)
-        draggingItem.setDraggingFrame(bounds, contents: image)
-        beginDraggingSession(with: [draggingItem], event: event, source: self)
-    }
-
-    private enum DragWriteError: Error {
-        case imageConversionFailed
-    }
-
-    private func writePromise(to destinationURL: URL) throws {
-        let fileManager = FileManager.default
-
-        if let savedURL = savedURL, fileManager.fileExists(atPath: savedURL.path) {
-            do {
-                try replaceItem(at: destinationURL, withItemAt: savedURL)
-                return
-            } catch {
-                // Fall through to image conversion if copy fails.
-            }
-        }
-
-        let tempURL = fileManager.temporaryDirectory.appendingPathComponent(
-            FileNaming.generateFilename(extension: "png")
-        )
-        defer { try? fileManager.removeItem(at: tempURL) }
-
-        try writeImage(to: tempURL)
-        try replaceItem(at: destinationURL, withItemAt: tempURL)
-    }
-
-    private func replaceItem(at destinationURL: URL, withItemAt sourceURL: URL) throws {
-        let fileManager = FileManager.default
-        if fileManager.fileExists(atPath: destinationURL.path) {
-            try fileManager.removeItem(at: destinationURL)
-        }
-        try fileManager.copyItem(at: sourceURL, to: destinationURL)
-    }
-
-    private func writeImage(to url: URL) throws {
-        guard let pngData = pngData(from: image) else {
-            throw DragWriteError.imageConversionFailed
-        }
-        try pngData.write(to: url, options: .atomic)
-    }
-
-    private func pngData(from image: NSImage) -> Data? {
-        guard let tiffData = image.tiffRepresentation,
-              let bitmap = NSBitmapImageRep(data: tiffData) else {
-            return nil
-        }
-        return bitmap.representation(using: .png, properties: [:])
+            .shadow(radius: 8)
     }
 }
 
@@ -513,13 +488,11 @@ struct ActiveVisualEffectView: NSViewRepresentable {
 #Preview {
     OverlayView(
         image: NSImage(systemSymbolName: "photo", accessibilityDescription: nil)!,
-        savedURL: URL(fileURLWithPath: "/tmp/test.png"),
         onCopy: {},
         onSave: {},
         onAnnotate: {},
         onPauseDismiss: {},
         onResumeDismiss: {},
-        onDragSuccess: {},
         onDismiss: {}
     )
     .padding(20)


### PR DESCRIPTION
## Summary
- add file-based drag source for the overlay thumbnail (file promise using saved file or temp PNG)
- pause overlay auto-dismiss on hover/drag and close on successful drop
- disable window background dragging to avoid conflicts

## Testing
- not run (per request)