### PR TITLE
Fix screenshot overlay showing square corners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Screenshot overlay no longer shows square corners at edges (proper layer masking)
 - Arrow and line annotations now move correctly when dragged (previously only selection box moved)
 - Window capture uses correct display scale factor on multi-monitor setups
 - Hotkeys automatically recover when system disables event tap due to timeout

--- a/Shotter/Resources/Info.plist
+++ b/Shotter/Resources/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.0</string>
+	<string>1.2.1</string>
 	<key>CFBundleVersion</key>
-	<string>120</string>
+	<string>121</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>LSUIElement</key>

--- a/Shotter/Sources/MenuBar/MenuBarController.swift
+++ b/Shotter/Sources/MenuBar/MenuBarController.swift
@@ -180,11 +180,13 @@ class MenuBarController: NSObject {
         UpdaterController.shared.checkForUpdates()
     }
 
+    // For test builds, add build identifier to informativeText:
+    // let buildNumber = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? ""
+    // "\n\nBuild: \(buildNumber) (workspace-name)"
     @objc private func aboutClicked() {
         let fullVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "1.0"
-        let version = fullVersion.split(separator: ".").prefix(2).joined(separator: ".")
         let alert = NSAlert()
-        alert.messageText = "Shotter v\(version)"
+        alert.messageText = "Shotter v\(fullVersion)"
         alert.informativeText = "© 2026 Daniel Ensign\n\ngithub.com/densign01/shotter"
         alert.alertStyle = .informational
         alert.icon = NSApp.applicationIconImage

--- a/Shotter/Sources/Overlay/OverlayController.swift
+++ b/Shotter/Sources/Overlay/OverlayController.swift
@@ -196,7 +196,7 @@ class OverlayWindow: NSPanel, NSDraggingSource, NSFilePromiseProviderDelegate {
         self.level = .floating
         self.isOpaque = false
         self.backgroundColor = .clear
-        self.hasShadow = true
+        self.hasShadow = false
         self.isMovableByWindowBackground = false
         self.hidesOnDeactivate = false
         self.ignoresMouseEvents = false
@@ -219,6 +219,8 @@ class OverlayWindow: NSPanel, NSDraggingSource, NSFilePromiseProviderDelegate {
         hostingView = NSHostingView(rootView: overlayView)
         hostingView?.wantsLayer = true
         hostingView?.layer?.backgroundColor = NSColor.clear.cgColor
+        hostingView?.layer?.cornerRadius = 10
+        hostingView?.layer?.masksToBounds = true
         hostingView?.frame = NSRect(x: 0, y: 0, width: overlayWidth, height: overlayHeight)
         self.contentView = hostingView
     }
@@ -420,56 +422,58 @@ struct OverlayView: View {
 
     var body: some View {
         // Image fills the fixed container (crops if needed), buttons anchor to image edges
-        Image(nsImage: image)
-            .resizable()
-            .aspectRatio(contentMode: .fill)
-            .frame(width: OverlayLayout.overlayWidth, height: OverlayLayout.overlayHeight)
-            .cornerRadius(10)
-            .overlay(
-                RoundedRectangle(cornerRadius: 10)
-                    .stroke(Color.white.opacity(0.2), lineWidth: 1)
-            )
-            .allowsHitTesting(false)
-            .frame(width: OverlayLayout.overlayWidth, height: OverlayLayout.overlayHeight)
-            .overlay(alignment: .topTrailing) {
-                // Floating action bar (top-right, inside image)
-                VStack(spacing: OverlayLayout.actionButtonSpacing) {
-                    OverlayActionButton(systemName: "doc.on.doc", action: onCopy)
-                        .help("Copy")
-                    OverlayActionButton(systemName: "folder", action: onSave)
-                        .help("Show in Finder")
-                    OverlayActionButton(systemName: "pencil.tip.crop.circle", action: onAnnotate)
-                        .help("Annotate")
-                    OverlayDeleteButton(action: onDelete)
-                        .help("Move to Trash")
-                }
-                .padding(OverlayLayout.actionBarInnerPadding)
-                .background(ActiveVisualEffectView(material: .hudWindow))
-                .cornerRadius(8)
-                .padding(OverlayLayout.actionBarOuterPadding)
-                .opacity(isHovering ? 1 : 0.7)
+        ZStack {
+            Image(nsImage: image)
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+                .frame(width: OverlayLayout.overlayWidth, height: OverlayLayout.overlayHeight)
+                .allowsHitTesting(false)
+        }
+        .frame(width: OverlayLayout.overlayWidth, height: OverlayLayout.overlayHeight)
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(Color.white.opacity(0.2), lineWidth: 1)
+        )
+        .overlay(alignment: .topTrailing) {
+            // Floating action bar (top-right, inside image)
+            VStack(spacing: OverlayLayout.actionButtonSpacing) {
+                OverlayActionButton(systemName: "doc.on.doc", action: onCopy)
+                    .help("Copy")
+                OverlayActionButton(systemName: "folder", action: onSave)
+                    .help("Show in Finder")
+                OverlayActionButton(systemName: "pencil.tip.crop.circle", action: onAnnotate)
+                    .help("Annotate")
+                OverlayDeleteButton(action: onDelete)
+                    .help("Move to Trash")
             }
-            .overlay(alignment: .topLeading) {
-                // Close button (top-left corner, inside image)
-                Button(action: onDismiss) {
-                    Image(systemName: "xmark.circle.fill")
-                        .font(.system(size: 18))
-                        .foregroundStyle(.white.opacity(0.8))
-                        .background(Circle().fill(Color.black.opacity(0.5)))
-                }
-                .buttonStyle(.plain)
-                .padding(10)
-                .opacity(isHovering ? 1 : 0.6)
+            .padding(OverlayLayout.actionBarInnerPadding)
+            .background(ActiveVisualEffectView(material: .hudWindow))
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+            .padding(OverlayLayout.actionBarOuterPadding)
+            .opacity(isHovering ? 1 : 0.7)
+        }
+        .overlay(alignment: .topLeading) {
+            // Close button (top-left corner, inside image)
+            Button(action: onDismiss) {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.system(size: 18))
+                    .foregroundStyle(.white.opacity(0.8))
+                    .background(Circle().fill(Color.black.opacity(0.5)))
             }
-            .shadow(radius: 8)
-            .onHover { hovering in
-                isHovering = hovering
-                if hovering {
-                    onPauseDismiss()
-                } else {
-                    onResumeDismiss()
-                }
+            .buttonStyle(.plain)
+            .padding(10)
+            .opacity(isHovering ? 1 : 0.6)
+        }
+        .shadow(radius: 8)
+        .onHover { hovering in
+            isHovering = hovering
+            if hovering {
+                onPauseDismiss()
+            } else {
+                onResumeDismiss()
             }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Fixes visual bug where screenshot overlay had visible square corners instead of smooth rounded edges
- The issue was caused by the NSPanel's rectangular window shadow showing at corners of rounded SwiftUI content

## Changes

- Disable window-level shadow (`hasShadow = false`) - SwiftUI `.shadow()` handles depth
- Add `cornerRadius` and `masksToBounds` to NSHostingView's layer for proper clipping
- Replace deprecated `.cornerRadius()` with `.clipShape(RoundedRectangle())` in SwiftUI
- Wrap image in ZStack for cleaner clipping hierarchy
- Bump version to 1.2.1

## Test plan

- [ ] Take a screenshot and verify overlay corners are smooth (no white/light edges visible)
- [ ] Verify overlay still has visible shadow/depth
- [ ] Test on both light and dark backgrounds

🤖 Generated with [Claude Code](https://claude.ai/claude-code)