### PR TITLE
Add keyboard shortcut hint when auto-copy is disabled

### DIFF
--- a/Shotter/Sources/Preferences/PreferencesView.swift
+++ b/Shotter/Sources/Preferences/PreferencesView.swift
@@ -50,7 +50,14 @@ struct PreferencesView: View {
 
                 Toggle("Play capture sound", isOn: $prefs.playCaptureSound)
 
-                Toggle("Auto-copy to clipboard", isOn: $prefs.autoCopyToClipboard)
+                VStack(alignment: .leading, spacing: 4) {
+                    Toggle("Auto-copy to clipboard", isOn: $prefs.autoCopyToClipboard)
+                    if !prefs.autoCopyToClipboard {
+                        Text("Hold ⌥ Option with your shortcut to copy")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                }
 
                 Toggle("Launch at login", isOn: $prefs.launchAtLogin)
             } header: {


### PR DESCRIPTION
## Summary
Shows a hint below the auto-copy toggle explaining how to manually copy when the setting is disabled. Users are guided to hold Option (⌥) with their shortcut keys to trigger a copy operation.

## Test Plan
- Disable auto-copy to clipboard in preferences
- Verify hint "Hold ⌥ Option with your shortcut to copy" appears below the toggle
- Re-enable auto-copy and verify the hint disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)