### PR TITLE
Add option to disable automatic screenshot saving

### DIFF
--- a/Shotter/Sources/App/ShotterApp.swift
+++ b/Shotter/Sources/App/ShotterApp.swift
@@ -143,9 +143,16 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             SoundManager.shared.playCaptureSound()
         }
 
-        // Save to file first (so we have a URL for clipboard)
-        let result = saveImage(image)
-        let savedURL = try? result.get()
+        // Only save immediately if auto-save is enabled
+        let result: Result<URL, SaveError>?
+        let savedURL: URL?
+        if prefs.autoSaveScreenshots {
+            result = saveImage(image)
+            savedURL = try? result?.get()
+        } else {
+            result = nil
+            savedURL = nil
+        }
 
         // Auto-copy to clipboard if enabled (must be on main thread for NSPasteboard)
         // Now includes file URL for terminal compatibility (Ghostty, etc.)
@@ -163,7 +170,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Show overlay
         DispatchQueue.main.async {
-            switch result {
+            // When auto-save is disabled (no result), show overlay with save functionality
+            if result == nil {
+                self.showOverlayWithManualSave(image: image)
+                return
+            }
+
+            // Auto-save was attempted - handle success or failure
+            switch result! {
             case .success(let savedURL):
                 self.overlayController?.showOverlay(
                     image: image,
@@ -185,28 +199,42 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 )
             case .failure(let error):
                 self.showSaveErrorAlert(error: error)
-                // Still show overlay but without save functionality
-                // No file URL available for clipboard in this case
-                self.overlayController?.showOverlay(
-                    image: image,
-                    savedURL: nil,
-                    onCopy: {
-                        self.copyToClipboard(image, fileURL: nil)
-                    },
-                    onSave: {
-                        // Can't show in Finder since save failed
-                    },
-                    onAnnotate: {
-                        DebugLogger.log("Overlay annotate clicked (no savedURL)")
-                        self.overlayController?.dismissOverlay()
-                        self.openAnnotationEditor(image: image, savedURL: nil)
-                    },
-                    onDelete: {
-                        // No file to delete since save failed
-                    }
-                )
+                // Auto-save failed - show overlay with manual save option to retry
+                self.showOverlayWithManualSave(image: image)
             }
         }
+    }
+
+    /// Shows overlay with manual save functionality (when auto-save is disabled)
+    private func showOverlayWithManualSave(image: NSImage) {
+        self.overlayController?.showOverlay(
+            image: image,
+            savedURL: nil,
+            onCopy: {
+                self.copyToClipboard(image, fileURL: nil)
+            },
+            onSave: {
+                // Manual save: save the file, then dismiss overlay
+                let result = self.saveImage(image)
+                switch result {
+                case .success(let url):
+                    logger.info("Manual save completed: \(url.path)")
+                    self.overlayController?.dismissOverlay()
+                case .failure(let error):
+                    self.showSaveErrorAlert(error: error)
+                }
+            },
+            onAnnotate: {
+                DebugLogger.log("Overlay annotate clicked (manual save mode)")
+                self.overlayController?.dismissOverlay()
+                self.openAnnotationEditor(image: image, savedURL: nil)
+            },
+            onDelete: {
+                // No file exists - just discard by dismissing overlay
+                logger.info("Discarding unsaved screenshot")
+                self.overlayController?.dismissOverlay()
+            }
+        )
     }
     
     private enum SaveError: LocalizedError {

--- a/Shotter/Sources/Overlay/OverlayController.swift
+++ b/Shotter/Sources/Overlay/OverlayController.swift
@@ -207,6 +207,7 @@ class OverlayWindow: NSPanel, NSDraggingSource, NSFilePromiseProviderDelegate {
         // Create SwiftUI view
         let overlayView = OverlayView(
             image: image,
+            hasSavedFile: savedURL != nil,
             onCopy: onCopy,
             onSave: onSave,
             onAnnotate: onAnnotate,
@@ -410,6 +411,7 @@ class OverlayWindow: NSPanel, NSDraggingSource, NSFilePromiseProviderDelegate {
 
 struct OverlayView: View {
     let image: NSImage
+    let hasSavedFile: Bool
     let onCopy: () -> Void
     let onSave: () -> Void
     let onAnnotate: () -> Void
@@ -440,12 +442,17 @@ struct OverlayView: View {
             VStack(spacing: OverlayLayout.actionButtonSpacing) {
                 OverlayActionButton(systemName: "doc.on.doc", action: onCopy)
                     .help("Copy")
-                OverlayActionButton(systemName: "folder", action: onSave)
-                    .help("Show in Finder")
+                // Show "Save" when no file exists, "Show in Finder" when file exists
+                OverlayActionButton(
+                    systemName: hasSavedFile ? "folder" : "square.and.arrow.down",
+                    action: onSave
+                )
+                .help(hasSavedFile ? "Show in Finder" : "Save")
                 OverlayActionButton(systemName: "pencil.tip.crop.circle", action: onAnnotate)
                     .help("Annotate")
+                // Show "Discard" when no file exists, "Move to Trash" when file exists
                 OverlayDeleteButton(action: onDelete)
-                    .help("Move to Trash")
+                    .help(hasSavedFile ? "Move to Trash" : "Discard")
             }
             .padding(OverlayLayout.actionBarInnerPadding)
             .background(ActiveVisualEffectView(material: .hudWindow))
@@ -541,6 +548,7 @@ struct ActiveVisualEffectView: NSViewRepresentable {
 #Preview {
     OverlayView(
         image: NSImage(systemSymbolName: "photo", accessibilityDescription: nil)!,
+        hasSavedFile: true,
         onCopy: {},
         onSave: {},
         onAnnotate: {},

--- a/Shotter/Sources/Preferences/PreferencesManager.swift
+++ b/Shotter/Sources/Preferences/PreferencesManager.swift
@@ -90,6 +90,7 @@ class PreferencesManager: ObservableObject {
         static let launchAtLogin = "launchAtLogin"
         static let playCaptureSound = "playCaptureSound"
         static let autoCopyToClipboard = "autoCopyToClipboard"
+        static let autoSaveScreenshots = "autoSaveScreenshots"
         static let shortcutFullscreen = "shortcutFullscreen"
         static let shortcutArea = "shortcutArea"
         static let shortcutWindow = "shortcutWindow"
@@ -124,6 +125,14 @@ class PreferencesManager: ObservableObject {
     @Published var autoCopyToClipboard: Bool {
         didSet {
             defaults.set(autoCopyToClipboard, forKey: Keys.autoCopyToClipboard)
+        }
+    }
+
+    /// When enabled, screenshots are saved to disk immediately after capture.
+    /// When disabled, screenshots are held in memory until user manually saves.
+    @Published var autoSaveScreenshots: Bool {
+        didSet {
+            defaults.set(autoSaveScreenshots, forKey: Keys.autoSaveScreenshots)
         }
     }
 
@@ -201,6 +210,13 @@ class PreferencesManager: ObservableObject {
 
         // Load auto-copy preference (default to false)
         autoCopyToClipboard = defaults.bool(forKey: Keys.autoCopyToClipboard)
+
+        // Load auto-save preference (default to true for backwards compatibility)
+        if defaults.object(forKey: Keys.autoSaveScreenshots) == nil {
+            autoSaveScreenshots = true
+        } else {
+            autoSaveScreenshots = defaults.bool(forKey: Keys.autoSaveScreenshots)
+        }
 
         // Load shortcuts
         shortcutFullscreen = Self.loadShortcut(from: defaults, forKey: Keys.shortcutFullscreen, default: .defaultFullscreen)

--- a/Shotter/Sources/Preferences/PreferencesView.swift
+++ b/Shotter/Sources/Preferences/PreferencesView.swift
@@ -52,6 +52,8 @@ struct PreferencesView: View {
 
                 Toggle("Auto-copy to clipboard", isOn: $prefs.autoCopyToClipboard)
 
+                Toggle("Save screenshots automatically", isOn: $prefs.autoSaveScreenshots)
+
                 Toggle("Launch at login", isOn: $prefs.launchAtLogin)
             } header: {
                 Text("General")


### PR DESCRIPTION
## Summary
- Adds "Save screenshots automatically" preference (enabled by default)
- When disabled, screenshots stay in memory and can be manually saved via overlay
- Overlay UI dynamically shows "Save" vs "Show in Finder" and "Discard" vs "Move to Trash" buttons based on file state

## Test plan
- Toggle "Save screenshots automatically" in preferences
- When enabled: screenshot saves immediately (existing behavior)
- When disabled: screenshot holds in memory, overlay shows "Save" button that saves on click
- Verify overlay buttons change labels appropriately based on saved state

🤖 Generated with [Claude Code](https://claude.com/claude-code)