### PR TITLE
Add zoom controls to annotation editor

### DIFF
--- a/Shotter/Sources/Annotations/AnnotationCanvasView.swift
+++ b/Shotter/Sources/Annotations/AnnotationCanvasView.swift
@@ -161,9 +161,27 @@ class AnnotationCanvasView: NSView {
     private func imageRectInView() -> CGRect {
         guard let state = state else { return .zero }
 
-        let imageRect = annotationImageRect(in: bounds.size, imageSize: state.imageSize)
-        scale = imageRect.width / state.imageSize.width
-        return imageRect
+        // Base fit-to-window rect
+        let fitRect = annotationImageRect(in: bounds.size, imageSize: state.imageSize)
+        let fitScale = fitRect.width / state.imageSize.width
+
+        if state.zoomLevel == 1.0 {
+            scale = fitScale
+            return fitRect
+        }
+
+        // Apply zoom relative to fit scale
+        let zoomedScale = fitScale * state.zoomLevel
+        scale = zoomedScale
+
+        let zoomedWidth = state.imageSize.width * zoomedScale
+        let zoomedHeight = state.imageSize.height * zoomedScale
+
+        // Center the zoomed image, offset by scroll
+        let originX = (bounds.width - zoomedWidth) / 2 + state.scrollOffset.x
+        let originY = (bounds.height - zoomedHeight) / 2 + state.scrollOffset.y
+
+        return CGRect(x: originX, y: originY, width: zoomedWidth, height: zoomedHeight)
     }
     
     private func drawCheckerboard(in rect: CGRect, context: CGContext) {
@@ -266,6 +284,33 @@ class AnnotationCanvasView: NSView {
         context.stroke(annotation.bounds)
     }
     
+    // MARK: - Scroll Wheel (Pan/Zoom)
+
+    override func scrollWheel(with event: NSEvent) {
+        guard let state = state, state.zoomLevel > 1.0 else {
+            super.scrollWheel(with: event)
+            return
+        }
+
+        // If Cmd held, zoom in/out
+        if event.modifierFlags.contains(.command) {
+            if event.scrollingDeltaY > 0 {
+                state.zoomIn()
+            } else if event.scrollingDeltaY < 0 {
+                state.zoomOut()
+            }
+            needsDisplay = true
+            return
+        }
+
+        // Pan when zoomed
+        state.scrollOffset = CGPoint(
+            x: state.scrollOffset.x + event.scrollingDeltaX,
+            y: state.scrollOffset.y - event.scrollingDeltaY
+        )
+        needsDisplay = true
+    }
+
     // MARK: - Coordinate Conversion
     
     func viewPointToImagePoint(_ viewPoint: CGPoint) -> CGPoint {

--- a/Shotter/Sources/Annotations/AnnotationEditorState.swift
+++ b/Shotter/Sources/Annotations/AnnotationEditorState.swift
@@ -17,6 +17,8 @@ class AnnotationEditorState: ObservableObject {
     @Published var nextCounterNumber: Int = 1
     @Published var cropRect: CGRect? = nil
     @Published private(set) var canvasFocusRequestID: Int = 0
+    @Published var zoomLevel: CGFloat = 1.0 // 1.0 = fit to window
+    @Published var scrollOffset: CGPoint = .zero
 
     // Modifier keys
     var isShiftKeyHeld: Bool = false
@@ -59,6 +61,29 @@ class AnnotationEditorState: ObservableObject {
         self.currentTool = AnnotationToolFactory.tool(for: .arrow)
     }
     
+    // MARK: - Zoom
+
+    static let zoomPresets: [CGFloat] = [0.25, 0.5, 0.75, 1.0, 1.5, 2.0, 3.0, 4.0]
+
+    func zoomIn() {
+        let nextLevel = Self.zoomPresets.first(where: { $0 > zoomLevel }) ?? zoomLevel
+        zoomLevel = nextLevel
+    }
+
+    func zoomOut() {
+        let prevLevel = Self.zoomPresets.last(where: { $0 < zoomLevel }) ?? zoomLevel
+        zoomLevel = prevLevel
+    }
+
+    func zoomToFit() {
+        zoomLevel = 1.0
+        scrollOffset = .zero
+    }
+
+    var zoomPercentage: Int {
+        Int(round(zoomLevel * 100))
+    }
+
     // MARK: - Tool Management
     
     func setTool(_ type: AnnotationToolType) {
@@ -430,6 +455,15 @@ extension AnnotationEditorState {
                 if selectedAnnotationId == nil, let first = annotations.first {
                     selectAnnotation(first.id)
                 }
+                return true
+            case "=", "+":
+                zoomIn()
+                return true
+            case "-":
+                zoomOut()
+                return true
+            case "0":
+                zoomToFit()
                 return true
             default:
                 break

--- a/Shotter/Sources/Annotations/AnnotationEditorWindow.swift
+++ b/Shotter/Sources/Annotations/AnnotationEditorWindow.swift
@@ -359,6 +359,8 @@ struct AnnotationEditorView: View {
                 // Bottom bar with tool options (always visible for consistent layout)
                 Divider()
                 ToolOptionsBar(state: state)
+                Divider()
+                ZoomControlsBar(state: state)
                 DragMeBar(state: state)
             }
             .background(Color(NSColor.controlBackgroundColor))
@@ -725,6 +727,57 @@ struct ToolOptionsBar: View {
         case .textHighlight:
             return "Drag to highlight"
         }
+    }
+}
+
+// MARK: - Zoom Controls Bar
+
+struct ZoomControlsBar: View {
+    @ObservedObject var state: AnnotationEditorState
+
+    var body: some View {
+        HStack(spacing: 8) {
+            // Zoom out button
+            Button(action: { state.zoomOut() }) {
+                Image(systemName: "minus.magnifyingglass")
+                    .font(.system(size: 12))
+            }
+            .buttonStyle(.plain)
+            .help("Zoom Out (\u{2318}-)")
+
+            // Zoom percentage dropdown
+            Menu {
+                ForEach(AnnotationEditorState.zoomPresets, id: \.self) { preset in
+                    Button("\(Int(preset * 100))%") {
+                        state.zoomLevel = preset
+                    }
+                }
+                Divider()
+                Button("Fit to Window") {
+                    state.zoomToFit()
+                }
+            } label: {
+                Text("\(state.zoomPercentage)%")
+                    .font(.caption)
+                    .monospacedDigit()
+                    .frame(minWidth: 40)
+            }
+            .menuStyle(.borderlessButton)
+            .frame(width: 60)
+
+            // Zoom in button
+            Button(action: { state.zoomIn() }) {
+                Image(systemName: "plus.magnifyingglass")
+                    .font(.system(size: 12))
+            }
+            .buttonStyle(.plain)
+            .help("Zoom In (\u{2318}+)")
+
+            Spacer()
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 4)
+        .background(Color(NSColor.windowBackgroundColor))
     }
 }
 


### PR DESCRIPTION
## Summary

- Adds visible zoom controls to the annotation editor bottom bar with zoom in/out buttons and a percentage dropdown (presets: 25%, 50%, 75%, 100%, 150%, 200%, 300%, 400%)
- Adds keyboard shortcuts: ⌘+ (zoom in), ⌘- (zoom out), ⌘0 (fit to window)
- Enables pan/scroll when zoomed in via scroll wheel, and ⌘+scroll for zoom
- Leverages existing `scale`/`offset` infrastructure in `AnnotationCanvasView`

Closes #31

## Test plan

- [ ] Open annotation editor with a screenshot
- [ ] Verify zoom controls appear in bottom bar between tool options and drag bar
- [ ] Click zoom in/out buttons and verify image scales correctly
- [ ] Use dropdown to select specific zoom levels (50%, 200%, etc.)
- [ ] Use ⌘+/⌘- keyboard shortcuts to zoom in/out
- [ ] Use ⌘0 to reset to fit-to-window
- [ ] When zoomed in, scroll to pan around the image
- [ ] Verify annotations still render correctly at different zoom levels
- [ ] Verify coordinate conversion (clicking to place annotations) works at zoom > 100%

https://claude.ai/code/session_01Kmj6o98J1TZBCcaWLDk4iT