### PR TITLE
Add timestamp + app name overlay to screenshots

### DIFF
--- a/Shotter/Sources/App/ShotterApp.swift
+++ b/Shotter/Sources/App/ShotterApp.swift
@@ -96,7 +96,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 logger.warning("Failed to capture fullscreen")
                 return
             }
-            handleCapture(result.image, preferredScreen: result.preferredScreen, directCopy: directCopy)
+            handleCapture(result.image, preferredScreen: result.preferredScreen, directCopy: directCopy, appName: result.appName)
         }
     }
 
@@ -107,7 +107,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 logger.info("Area capture returned nil (user cancelled or failed)")
                 return
             }
-            handleCapture(result.image, preferredScreen: result.preferredScreen, directCopy: directCopy)
+            handleCapture(result.image, preferredScreen: result.preferredScreen, directCopy: directCopy, appName: result.appName)
         }
     }
 
@@ -118,22 +118,34 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 logger.info("Window capture returned nil (user cancelled or failed)")
                 return
             }
-            handleCapture(result.image, preferredScreen: result.preferredScreen, directCopy: directCopy)
+            handleCapture(result.image, preferredScreen: result.preferredScreen, directCopy: directCopy, appName: result.appName)
         }
     }
-    
+
     private func captureDisplay(_ display: CaptureDisplay) {
         Task {
             guard let result = await captureEngine?.captureDisplay(display) else {
                 logger.warning("Failed to capture display: \(display.name)")
                 return
             }
-            handleCapture(result.image, preferredScreen: result.preferredScreen)
+            handleCapture(result.image, preferredScreen: result.preferredScreen, appName: result.appName)
         }
     }
     
-    private func handleCapture(_ image: NSImage, preferredScreen: NSScreen? = nil, directCopy: Bool = false) {
+    private func handleCapture(_ image: NSImage, preferredScreen: NSScreen? = nil, directCopy: Bool = false, appName: String? = nil) {
         let prefs = PreferencesManager.shared
+
+        // Apply timestamp overlay if enabled
+        let processedImage: NSImage
+        if prefs.timestampOverlayEnabled {
+            processedImage = TimestampOverlay.apply(
+                to: image,
+                appName: appName,
+                position: prefs.timestampOverlayPosition
+            )
+        } else {
+            processedImage = image
+        }
 
         // Direct-copy mode: Option held + auto-copy is OFF → copy and skip overlay
         let shouldDirectCopy = directCopy && !prefs.autoCopyToClipboard
@@ -147,7 +159,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let result: Result<URL, SaveError>?
         let savedURL: URL?
         if prefs.autoSaveScreenshots {
-            result = saveImage(image)
+            result = saveImage(processedImage)
             savedURL = try? result?.get()
         } else {
             result = nil
@@ -158,7 +170,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Now includes file URL for terminal compatibility (Ghostty, etc.)
         if prefs.autoCopyToClipboard || shouldDirectCopy {
             DispatchQueue.main.async {
-                self.copyToClipboard(image, fileURL: savedURL)
+                self.copyToClipboard(processedImage, fileURL: savedURL)
             }
         }
 

--- a/Shotter/Sources/Capture/CaptureEngine.swift
+++ b/Shotter/Sources/Capture/CaptureEngine.swift
@@ -27,6 +27,13 @@ struct AreaCaptureResult {
 struct CaptureResult {
     let image: NSImage
     let preferredScreen: NSScreen?
+    let appName: String?
+
+    init(image: NSImage, preferredScreen: NSScreen?, appName: String? = nil) {
+        self.image = image
+        self.preferredScreen = preferredScreen
+        self.appName = appName
+    }
 }
 
 class CaptureEngine {
@@ -331,7 +338,8 @@ class CaptureEngine {
             )
             return CaptureResult(
                 image: NSImage(cgImage: image, size: NSSize(width: window.frame.width, height: window.frame.height)),
-                preferredScreen: containingScreen
+                preferredScreen: containingScreen,
+                appName: window.owningApplication?.applicationName
             )
         } catch {
             logger.error("Failed to capture window: \(error.localizedDescription)")

--- a/Shotter/Sources/Preferences/PreferencesManager.swift
+++ b/Shotter/Sources/Preferences/PreferencesManager.swift
@@ -19,6 +19,23 @@ enum OverlayPosition: String, CaseIterable {
     }
 }
 
+/// Position for the timestamp overlay on screenshots
+enum TimestampPosition: String, CaseIterable {
+    case topLeft = "topLeft"
+    case topRight = "topRight"
+    case bottomLeft = "bottomLeft"
+    case bottomRight = "bottomRight"
+
+    var displayName: String {
+        switch self {
+        case .topLeft: return "Top Left"
+        case .topRight: return "Top Right"
+        case .bottomLeft: return "Bottom Left"
+        case .bottomRight: return "Bottom Right"
+        }
+    }
+}
+
 /// Represents a keyboard shortcut configuration
 struct ShortcutConfig: Codable, Equatable {
     var keyCode: Int
@@ -96,6 +113,8 @@ class PreferencesManager: ObservableObject {
         static let shortcutArea = "shortcutArea"
         static let shortcutWindow = "shortcutWindow"
         static let overlayPosition = "overlayPosition"
+        static let timestampOverlayEnabled = "timestampOverlayEnabled"
+        static let timestampOverlayPosition = "timestampOverlayPosition"
     }
     
     @Published var saveLocation: URL {
@@ -167,6 +186,18 @@ class PreferencesManager: ObservableObject {
         }
     }
 
+    @Published var timestampOverlayEnabled: Bool {
+        didSet {
+            defaults.set(timestampOverlayEnabled, forKey: Keys.timestampOverlayEnabled)
+        }
+    }
+
+    @Published var timestampOverlayPosition: TimestampPosition {
+        didSet {
+            defaults.set(timestampOverlayPosition.rawValue, forKey: Keys.timestampOverlayPosition)
+        }
+    }
+
     private func saveShortcut(_ config: ShortcutConfig, forKey key: String) {
         if let data = try? JSONEncoder().encode(config) {
             defaults.set(data, forKey: key)
@@ -235,6 +266,17 @@ class PreferencesManager: ObservableObject {
             overlayPosition = position
         } else {
             overlayPosition = .bottomLeft
+        }
+
+        // Load timestamp overlay preference (default to false)
+        timestampOverlayEnabled = defaults.bool(forKey: Keys.timestampOverlayEnabled)
+
+        // Load timestamp position (default to bottom-right)
+        if let positionString = defaults.string(forKey: Keys.timestampOverlayPosition),
+           let position = TimestampPosition(rawValue: positionString) {
+            timestampOverlayPosition = position
+        } else {
+            timestampOverlayPosition = .bottomRight
         }
 
         defaults.set(actualLaunchAtLogin, forKey: Keys.launchAtLogin)

--- a/Shotter/Sources/Preferences/PreferencesView.swift
+++ b/Shotter/Sources/Preferences/PreferencesView.swift
@@ -61,6 +61,23 @@ struct PreferencesView: View {
 
                 Toggle("Save screenshots automatically", isOn: $prefs.autoSaveScreenshots)
 
+                VStack(alignment: .leading, spacing: 4) {
+                    Toggle("Add timestamp overlay", isOn: $prefs.timestampOverlayEnabled)
+                    if prefs.timestampOverlayEnabled {
+                        HStack {
+                            Text("Position:")
+                            Spacer()
+                            Picker("", selection: $prefs.timestampOverlayPosition) {
+                                ForEach(TimestampPosition.allCases, id: \.self) { position in
+                                    Text(position.displayName).tag(position)
+                                }
+                            }
+                            .frame(width: 120)
+                        }
+                        .padding(.leading, 20)
+                    }
+                }
+
                 Toggle("Launch at login", isOn: $prefs.launchAtLogin)
             } header: {
                 Text("General")

--- a/Shotter/Sources/Utils/TimestampOverlay.swift
+++ b/Shotter/Sources/Utils/TimestampOverlay.swift
@@ -1,0 +1,71 @@
+import AppKit
+
+struct TimestampOverlay {
+    /// Apply a timestamp + app name overlay to the screenshot
+    static func apply(
+        to image: NSImage,
+        appName: String?,
+        position: TimestampPosition
+    ) -> NSImage {
+        let size = image.size
+        let result = NSImage(size: size)
+
+        result.lockFocus()
+
+        // Draw original image
+        image.draw(in: CGRect(origin: .zero, size: size))
+
+        // Format timestamp
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        let timestamp = formatter.string(from: Date())
+
+        // Build overlay text
+        var overlayText = timestamp
+        if let appName = appName, !appName.isEmpty {
+            overlayText = "\(appName) — \(timestamp)"
+        }
+
+        // Calculate font size relative to image (auto-scale)
+        let baseFontSize = max(11, min(16, size.width / 80))
+        let font = NSFont.systemFont(ofSize: baseFontSize, weight: .medium)
+
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: font,
+            .foregroundColor: NSColor.white
+        ]
+
+        let textSize = (overlayText as NSString).size(withAttributes: attributes)
+        let padding: CGFloat = baseFontSize * 0.6
+        let bgHeight = textSize.height + padding * 2
+        let bgWidth = textSize.width + padding * 2
+
+        // Calculate position
+        let bgRect: CGRect
+        switch position {
+        case .topLeft:
+            bgRect = CGRect(x: 0, y: size.height - bgHeight, width: bgWidth, height: bgHeight)
+        case .topRight:
+            bgRect = CGRect(x: size.width - bgWidth, y: size.height - bgHeight, width: bgWidth, height: bgHeight)
+        case .bottomLeft:
+            bgRect = CGRect(x: 0, y: 0, width: bgWidth, height: bgHeight)
+        case .bottomRight:
+            bgRect = CGRect(x: size.width - bgWidth, y: 0, width: bgWidth, height: bgHeight)
+        }
+
+        // Draw semi-transparent background
+        NSColor.black.withAlphaComponent(0.5).setFill()
+        let bgPath = NSBezierPath(roundedRect: bgRect, xRadius: 4, yRadius: 4)
+        bgPath.fill()
+
+        // Draw text
+        let textPoint = CGPoint(
+            x: bgRect.origin.x + padding,
+            y: bgRect.origin.y + padding
+        )
+        (overlayText as NSString).draw(at: textPoint, withAttributes: attributes)
+
+        result.unlockFocus()
+        return result
+    }
+}


### PR DESCRIPTION
## Summary

- Adds optional timestamp + app name overlay stamped onto screenshots at capture time
- New toggle in Preferences: "Add timestamp overlay" with configurable corner position (top-left, top-right, bottom-left, bottom-right)
- Overlay renders as a semi-transparent rounded badge with white text, font size auto-scales to image dimensions
- Window captures include the source app name (e.g. "Safari — 2026-03-23 14:30:00"); fullscreen/area captures show timestamp only
- Extended `CaptureResult` with optional `appName` from `SCWindow.owningApplication`

Closes #27

## Test plan

- [ ] Enable "Add timestamp overlay" in Preferences
- [ ] Capture a fullscreen screenshot — verify timestamp badge appears at chosen corner
- [ ] Capture a window screenshot — verify both app name and timestamp appear
- [ ] Change overlay position in Preferences — verify it moves to the new corner
- [ ] Disable the toggle — verify screenshots have no overlay
- [ ] Verify overlay text is readable at different screenshot sizes
- [ ] Verify overlay doesn't interfere with annotation editor (overlay is baked into the image)

https://claude.ai/code/session_01Kmj6o98J1TZBCcaWLDk4iT