### PR TITLE
Add zoom controls to annotation editor

### DIFF
--- a/Shotter/Sources/Annotations/AnnotationCanvasView.swift
+++ b/Shotter/Sources/Annotations/AnnotationCanvasView.swift
@@ -161,9 +161,19 @@ class AnnotationCanvasView: NSView {
     private func imageRectInView() -> CGRect {
         guard let state = state else { return .zero }
 
-        let imageRect = annotationImageRect(in: bounds.size, imageSize: state.imageSize)
-        scale = imageRect.width / state.imageSize.width
-        return imageRect
+        let fitRect = annotationImageRect(in: bounds.size, imageSize: state.imageSize)
+        let fitScale = fitRect.width / state.imageSize.width
+
+        let effectiveScale = fitScale * state.zoomLevel
+        scale = effectiveScale
+
+        let scaledWidth = state.imageSize.width * effectiveScale
+        let scaledHeight = state.imageSize.height * effectiveScale
+
+        let originX = (bounds.width - scaledWidth) / 2 + state.panOffset.x
+        let originY = (bounds.height - scaledHeight) / 2 + state.panOffset.y
+
+        return CGRect(x: originX, y: originY, width: scaledWidth, height: scaledHeight)
     }
     
     private func drawCheckerboard(in rect: CGRect, context: CGContext) {
@@ -266,6 +276,27 @@ class AnnotationCanvasView: NSView {
         context.stroke(annotation.bounds)
     }
     
+    // MARK: - Scroll Wheel (Zoom & Pan)
+
+    override func scrollWheel(with event: NSEvent) {
+        guard let state = state else { return }
+
+        if event.modifierFlags.contains(.command) || event.phase == .changed && event.momentumPhase == .init(rawValue: 0) {
+            // Pinch-to-zoom or Cmd+scroll
+            let delta = event.scrollingDeltaY
+            if abs(delta) > 0.1 {
+                let newZoom = state.zoomLevel * (1.0 + delta * 0.01)
+                state.setZoom(newZoom)
+                needsDisplay = true
+            }
+        } else if state.zoomLevel > 1.0 {
+            // Pan when zoomed in
+            state.panOffset.x += event.scrollingDeltaX
+            state.panOffset.y -= event.scrollingDeltaY
+            needsDisplay = true
+        }
+    }
+
     // MARK: - Coordinate Conversion
     
     func viewPointToImagePoint(_ viewPoint: CGPoint) -> CGPoint {

--- a/Shotter/Sources/Annotations/AnnotationEditorState.swift
+++ b/Shotter/Sources/Annotations/AnnotationEditorState.swift
@@ -18,6 +18,14 @@ class AnnotationEditorState: ObservableObject {
     @Published var cropRect: CGRect? = nil
     @Published private(set) var canvasFocusRequestID: Int = 0
 
+    // Zoom and pan
+    @Published var zoomLevel: CGFloat = 1.0
+    @Published var panOffset: CGPoint = .zero
+
+    static let zoomLevels: [CGFloat] = [0.25, 0.5, 0.75, 1.0, 1.5, 2.0, 3.0, 4.0]
+    static let minZoom: CGFloat = 0.25
+    static let maxZoom: CGFloat = 4.0
+
     // Modifier keys
     var isShiftKeyHeld: Bool = false
     
@@ -218,6 +226,37 @@ class AnnotationEditorState: ObservableObject {
         selectedAnnotationId = nil
     }
     
+    // MARK: - Zoom
+
+    func zoomIn() {
+        let next = Self.zoomLevels.first(where: { $0 > zoomLevel }) ?? Self.maxZoom
+        setZoom(next)
+    }
+
+    func zoomOut() {
+        let prev = Self.zoomLevels.last(where: { $0 < zoomLevel }) ?? Self.minZoom
+        setZoom(prev)
+    }
+
+    func zoomToFit() {
+        zoomLevel = 1.0
+        panOffset = .zero
+    }
+
+    func setZoom(_ level: CGFloat) {
+        zoomLevel = min(max(level, Self.minZoom), Self.maxZoom)
+        if zoomLevel <= 1.0 {
+            panOffset = .zero
+        }
+    }
+
+    var zoomDisplayString: String {
+        if zoomLevel == 1.0 {
+            return "Fit"
+        }
+        return "\(Int(round(zoomLevel * 100)))%"
+    }
+
     // MARK: - Text Editing
     
     func updateTextAnnotation(id: AnnotationID, text: String) {
@@ -430,6 +469,20 @@ extension AnnotationEditorState {
                 if selectedAnnotationId == nil, let first = annotations.first {
                     selectAnnotation(first.id)
                 }
+                return true
+            default:
+                break
+            }
+            // Zoom shortcuts by keyCode
+            switch event.keyCode {
+            case 24: // Cmd+=  (plus/equals key)
+                zoomIn()
+                return true
+            case 27: // Cmd+-
+                zoomOut()
+                return true
+            case 29: // Cmd+0
+                zoomToFit()
                 return true
             default:
                 break

--- a/Shotter/Sources/Annotations/AnnotationEditorWindow.swift
+++ b/Shotter/Sources/Annotations/AnnotationEditorWindow.swift
@@ -369,12 +369,14 @@ struct AnnotationEditorView: View {
         let imageSize = state.imageSize
         let imageAspect = imageSize.width / imageSize.height
         let viewAspect = viewSize.width / viewSize.height
-        
+
+        let fitScale: CGFloat
         if imageAspect > viewAspect {
-            return viewSize.width / imageSize.width
+            fitScale = viewSize.width / imageSize.width
         } else {
-            return viewSize.height / imageSize.height
+            fitScale = viewSize.height / imageSize.height
         }
+        return fitScale * state.zoomLevel
     }
 }
 
@@ -663,6 +665,42 @@ struct ToolOptionsBar: View {
             }
 
             Spacer()
+
+            // Zoom controls
+            HStack(spacing: 4) {
+                Button(action: { state.zoomOut() }) {
+                    Image(systemName: "minus.magnifyingglass")
+                        .font(.system(size: 12))
+                }
+                .buttonStyle(.plain)
+                .disabled(state.zoomLevel <= AnnotationEditorState.minZoom)
+                .help("Zoom Out (⌘-)")
+
+                Picker("", selection: Binding(
+                    get: { state.zoomLevel },
+                    set: { state.setZoom($0) }
+                )) {
+                    Text("Fit").tag(CGFloat(1.0))
+                    Text("50%").tag(CGFloat(0.5))
+                    Text("75%").tag(CGFloat(0.75))
+                    Text("150%").tag(CGFloat(1.5))
+                    Text("200%").tag(CGFloat(2.0))
+                    Text("300%").tag(CGFloat(3.0))
+                }
+                .pickerStyle(.menu)
+                .frame(width: 70)
+
+                Button(action: { state.zoomIn() }) {
+                    Image(systemName: "plus.magnifyingglass")
+                        .font(.system(size: 12))
+                }
+                .buttonStyle(.plain)
+                .disabled(state.zoomLevel >= AnnotationEditorState.maxZoom)
+                .help("Zoom In (⌘+)")
+            }
+
+            Divider()
+                .frame(height: 20)
 
             // Keyboard shortcut hints (always visible)
             Text(keyboardHint)


### PR DESCRIPTION
## Summary
Closes #31

Adds visible zoom controls to the annotation editor, enabling precise annotation work at different magnification levels.

### Changes
- **`AnnotationEditorState`**: Added `zoomLevel`, `panOffset`, `zoomIn()`, `zoomOut()`, `zoomToFit()` with predefined zoom levels (25%-400%)
- **`AnnotationCanvasView`**: Updated `imageRectInView()` to apply zoom+pan, added `scrollWheel` handler for Cmd+scroll zoom and pan when zoomed in
- **`AnnotationEditorWindow`**: Added zoom controls (magnifying glass buttons + percentage display + fit button) to `ToolOptionsBar`, updated `calculateScale` and text editor overlay positioning for zoom

### Keyboard shortcuts
- `⌘+` / `⌘=` — Zoom in
- `⌘-` — Zoom out
- `⌘0` — Zoom to fit
- `⌘+scroll` — Zoom with trackpad/mouse
- Scroll when zoomed in — Pan

## Test plan
- [ ] Open annotation editor and verify default "Fit" zoom (100%)
- [ ] Use ⌘+/⌘- to zoom in/out through levels (25%, 50%, 75%, 100%, 150%, 200%, 300%, 400%)
- [ ] Use ⌘+scroll wheel to zoom
- [ ] Pan with scroll wheel when zoomed in (>100%)
- [ ] Verify annotations render correctly at all zoom levels
- [ ] Verify clicking/drawing annotations works at all zoom levels (coordinate conversion)
- [ ] Use ⌘0 to reset to fit-to-window
- [ ] Verify zoom controls in bottom bar update correctly

https://claude.ai/code/session_013HbtbYeXXYypFoDpJRPxDv