### PR TITLE
Wire up scrolling capture to UI with shortcut and menu

### DIFF
--- a/Shotter/Sources/App/ShotterApp.swift
+++ b/Shotter/Sources/App/ShotterApp.swift
@@ -52,6 +52,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             onCaptureFullscreen: { [weak self] in self?.captureFullscreen() },
             onCaptureArea: { [weak self] in self?.captureArea() },
             onCaptureWindow: { [weak self] in self?.captureWindow() },
+            onCaptureScrolling: { [weak self] in self?.captureScrolling() },
             onCaptureDisplay: { [weak self] display in self?.captureDisplay(display) },
             onOpenSaveFolder: { self.openSaveFolder() },
             onOpenPreferences: { self.openPreferences() },
@@ -60,11 +61,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 await self?.captureEngine?.getAvailableDisplays() ?? []
             }
         )
-        
+
         hotkeyManager = HotkeyManager(
             onFullscreen: { [weak self] directCopy in self?.captureFullscreen(directCopy: directCopy) },
             onArea: { [weak self] directCopy in self?.captureArea(directCopy: directCopy) },
-            onWindow: { [weak self] directCopy in self?.captureWindow(directCopy: directCopy) }
+            onWindow: { [weak self] directCopy in self?.captureWindow(directCopy: directCopy) },
+            onScrolling: { [weak self] directCopy in self?.captureScrolling(directCopy: directCopy) }
         )
         
         // Check permissions on launch
@@ -121,7 +123,17 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             handleCapture(result.image, preferredScreen: result.preferredScreen, directCopy: directCopy)
         }
     }
-    
+
+    private func captureScrolling(directCopy: Bool = false) {
+        Task {
+            guard let result = await captureEngine?.captureScrolling() else {
+                logger.info("Scrolling capture returned nil (user cancelled or failed)")
+                return
+            }
+            handleCapture(result.image, preferredScreen: result.preferredScreen, directCopy: directCopy)
+        }
+    }
+
     private func captureDisplay(_ display: CaptureDisplay) {
         Task {
             guard let result = await captureEngine?.captureDisplay(display) else {

--- a/Shotter/Sources/Capture/CaptureEngine.swift
+++ b/Shotter/Sources/Capture/CaptureEngine.swift
@@ -347,6 +347,38 @@ class CaptureEngine {
         return await captureWindow(window)
     }
 
+    // MARK: - Scrolling Capture
+
+    /// Show window picker, then perform a scrolling capture of the selected window
+    func captureScrolling() async -> CaptureResult? {
+        guard let window = await showWindowSelector() else {
+            return nil
+        }
+
+        // Use the window center as the click point, converted from SCK to Cocoa coordinates
+        let windowFrame = window.frame
+        let centerSCK = CGPoint(x: windowFrame.midX, y: windowFrame.midY)
+        let clickPoint = NSScreen.convertFromSCK(centerSCK)
+        let selection = WindowSelectionResult(window: window, clickPoint: clickPoint)
+
+        let session = ScrollingCaptureSession(selection: selection) { [weak self] scWindow in
+            guard let result = await self?.captureWindow(scWindow) else { return nil }
+            return result.image
+        }
+
+        guard let image = await session.capture() else {
+            logger.error("Scrolling capture failed")
+            return nil
+        }
+
+        // Determine the preferred screen from the window position
+        let mainScreenHeight = NSScreen.screens.first?.frame.height ?? 0
+        let cocoaCenter = NSPoint(x: windowFrame.midX, y: mainScreenHeight - windowFrame.midY)
+        let containingScreen = NSScreen.screens.first { $0.frame.contains(cocoaCenter) }
+
+        return CaptureResult(image: image, preferredScreen: containingScreen)
+    }
+
     // MARK: - Selectors
 
     @MainActor

--- a/Shotter/Sources/Hotkeys/HotkeyManager.swift
+++ b/Shotter/Sources/Hotkeys/HotkeyManager.swift
@@ -13,26 +13,31 @@ class HotkeyManager {
     private let onFullscreen: (Bool) -> Void  // Bool = directCopy (Option held)
     private let onArea: (Bool) -> Void
     private let onWindow: (Bool) -> Void
-    
+    private let onScrolling: (Bool) -> Void
+
     // Cache shortcuts for performance
     private var fullscreenShortcut: ShortcutConfig
     private var areaShortcut: ShortcutConfig
     private var windowShortcut: ShortcutConfig
-    
+    private var scrollingShortcut: ShortcutConfig
+
     init(
         onFullscreen: @escaping (Bool) -> Void,
         onArea: @escaping (Bool) -> Void,
-        onWindow: @escaping (Bool) -> Void
+        onWindow: @escaping (Bool) -> Void,
+        onScrolling: @escaping (Bool) -> Void
     ) {
         self.onFullscreen = onFullscreen
         self.onArea = onArea
         self.onWindow = onWindow
-        
+        self.onScrolling = onScrolling
+
         // Load initial shortcuts
         let prefs = PreferencesManager.shared
         self.fullscreenShortcut = prefs.shortcutFullscreen
         self.areaShortcut = prefs.shortcutArea
         self.windowShortcut = prefs.shortcutWindow
+        self.scrollingShortcut = prefs.shortcutScrolling
         
         setupEventTap()
         observeShortcutChanges()
@@ -64,6 +69,7 @@ class HotkeyManager {
         fullscreenShortcut = prefs.shortcutFullscreen
         areaShortcut = prefs.shortcutArea
         windowShortcut = prefs.shortcutWindow
+        scrollingShortcut = prefs.shortcutScrolling
         logger.info("Shortcuts reloaded")
     }
 
@@ -194,7 +200,21 @@ class HotkeyManager {
             }
             return nil // Consume the event
         }
-        
+
+        // Check scrolling capture shortcut
+        if scrollingShortcut.isEnabled && matchesShortcut(keyCode: keyCode, flags: flags, shortcut: scrollingShortcut, allowExtraOption: true) {
+            guard Permissions.checkScreenRecordingSync(forceRefresh: true) else {
+                logger.info("Screen recording unavailable - allowing native scrolling shortcut")
+                return Unmanaged.passRetained(event)
+            }
+
+            let directCopyRequested = directCopyRequested(flags: flags, shortcut: scrollingShortcut)
+            DispatchQueue.main.async {
+                self.onScrolling(directCopyRequested)
+            }
+            return nil // Consume the event
+        }
+
         return Unmanaged.passRetained(event)
     }
     

--- a/Shotter/Sources/MenuBar/MenuBarController.swift
+++ b/Shotter/Sources/MenuBar/MenuBarController.swift
@@ -7,16 +7,18 @@ class MenuBarController: NSObject {
     private let onCaptureFullscreen: () -> Void
     private let onCaptureArea: () -> Void
     private let onCaptureWindow: () -> Void
+    private let onCaptureScrolling: () -> Void
     private let onCaptureDisplay: (CaptureDisplay) -> Void
     private let onOpenSaveFolder: () -> Void
     private let onOpenPreferences: () -> Void
     private let onQuit: () -> Void
     private let getDisplays: () async -> [CaptureDisplay]
-    
+
     init(
         onCaptureFullscreen: @escaping () -> Void,
         onCaptureArea: @escaping () -> Void,
         onCaptureWindow: @escaping () -> Void,
+        onCaptureScrolling: @escaping () -> Void,
         onCaptureDisplay: @escaping (CaptureDisplay) -> Void,
         onOpenSaveFolder: @escaping () -> Void,
         onOpenPreferences: @escaping () -> Void,
@@ -26,6 +28,7 @@ class MenuBarController: NSObject {
         self.onCaptureFullscreen = onCaptureFullscreen
         self.onCaptureArea = onCaptureArea
         self.onCaptureWindow = onCaptureWindow
+        self.onCaptureScrolling = onCaptureScrolling
         self.onCaptureDisplay = onCaptureDisplay
         self.onOpenSaveFolder = onOpenSaveFolder
         self.onOpenPreferences = onOpenPreferences
@@ -82,7 +85,17 @@ class MenuBarController: NSObject {
         windowItem.keyEquivalent = "5"
         windowItem.target = self
         menu.addItem(windowItem)
-        
+
+        let scrollingItem = NSMenuItem(
+            title: "Capture Scrolling",
+            action: #selector(captureScrollingClicked),
+            keyEquivalent: ""
+        )
+        scrollingItem.keyEquivalentModifierMask = [.command, .shift]
+        scrollingItem.keyEquivalent = "6"
+        scrollingItem.target = self
+        menu.addItem(scrollingItem)
+
         menu.addItem(NSMenuItem.separator())
         
         // Capture Display submenu (populated dynamically)
@@ -161,7 +174,11 @@ class MenuBarController: NSObject {
     @objc private func captureWindowClicked() {
         onCaptureWindow()
     }
-    
+
+    @objc private func captureScrollingClicked() {
+        onCaptureScrolling()
+    }
+
     @objc private func captureDisplayClicked(_ sender: NSMenuItem) {
         guard sender.tag < displays.count else { return }
         let display = displays[sender.tag]

--- a/Shotter/Sources/Preferences/PreferencesManager.swift
+++ b/Shotter/Sources/Preferences/PreferencesManager.swift
@@ -77,6 +77,13 @@ struct ShortcutConfig: Codable, Equatable {
         modifiers: Int(CGEventFlags.maskCommand.rawValue | CGEventFlags.maskShift.rawValue),
         isEnabled: false  // Disabled by default; users can enable if they want direct window shortcut
     )
+
+    /// Default ⌘⇧6 for scrolling capture
+    static let defaultScrolling = ShortcutConfig(
+        keyCode: 22,  // "6"
+        modifiers: Int(CGEventFlags.maskCommand.rawValue | CGEventFlags.maskShift.rawValue),
+        isEnabled: true
+    )
 }
 
 class PreferencesManager: ObservableObject {
@@ -95,6 +102,7 @@ class PreferencesManager: ObservableObject {
         static let shortcutFullscreen = "shortcutFullscreen"
         static let shortcutArea = "shortcutArea"
         static let shortcutWindow = "shortcutWindow"
+        static let shortcutScrolling = "shortcutScrolling"
         static let overlayPosition = "overlayPosition"
     }
     
@@ -157,6 +165,13 @@ class PreferencesManager: ObservableObject {
     @Published var shortcutWindow: ShortcutConfig {
         didSet {
             saveShortcut(shortcutWindow, forKey: Keys.shortcutWindow)
+            NotificationCenter.default.post(name: .shortcutsDidChange, object: nil)
+        }
+    }
+
+    @Published var shortcutScrolling: ShortcutConfig {
+        didSet {
+            saveShortcut(shortcutScrolling, forKey: Keys.shortcutScrolling)
             NotificationCenter.default.post(name: .shortcutsDidChange, object: nil)
         }
     }
@@ -228,6 +243,7 @@ class PreferencesManager: ObservableObject {
         shortcutFullscreen = Self.loadShortcut(from: defaults, forKey: Keys.shortcutFullscreen, default: .defaultFullscreen)
         shortcutArea = Self.loadShortcut(from: defaults, forKey: Keys.shortcutArea, default: .defaultArea)
         shortcutWindow = Self.loadShortcut(from: defaults, forKey: Keys.shortcutWindow, default: .defaultWindow)
+        shortcutScrolling = Self.loadShortcut(from: defaults, forKey: Keys.shortcutScrolling, default: .defaultScrolling)
 
         // Load overlay position (default to bottom-left)
         if let positionString = defaults.string(forKey: Keys.overlayPosition),


### PR DESCRIPTION
## Summary
Closes #35

- Adds `captureScrolling()` method to `CaptureEngine` using existing `ScrollingCaptureSession`
- Adds "Capture Scrolling" menu item to the status bar menu
- Adds `Cmd+Shift+6` keyboard shortcut for scrolling capture
- Adds shortcut config to `PreferencesManager`
- Wires up the full flow: select window → auto-scroll → stitch frames → show overlay

The `ScrollingCaptureSession` was already fully implemented but not exposed in the UI. This PR connects it.

## Test plan
- [ ] Use Cmd+Shift+6 to trigger scrolling capture
- [ ] Select a window with scrollable content (e.g., long web page)
- [ ] Verify the app auto-scrolls and captures multiple frames
- [ ] Verify the stitched result appears in the overlay
- [ ] Test with non-scrollable window (should fall back to single capture)
- [ ] Verify "Capture Scrolling" appears in the menu bar dropdown
- [ ] Test shortcut customization in Preferences

https://claude.ai/code/session_01FjXdHBaU5S1RoqxX4yHYNx