### PR TITLE
Add background customization to annotation editor

### DIFF
--- a/Shotter/Sources/Annotations/AnnotationEditorState.swift
+++ b/Shotter/Sources/Annotations/AnnotationEditorState.swift
@@ -16,6 +16,7 @@ class AnnotationEditorState: ObservableObject {
     @Published var editingTextAnnotationId: AnnotationID?
     @Published var nextCounterNumber: Int = 1
     @Published var cropRect: CGRect? = nil
+    @Published var backgroundConfig: BackgroundConfig = BackgroundConfig()
     @Published private(set) var canvasFocusRequestID: Int = 0
 
     // Modifier keys
@@ -39,9 +40,11 @@ class AnnotationEditorState: ObservableObject {
     private(set) var imageSize: CGSize
     private(set) var hasBeenCropped: Bool = false
 
+    var hasBackground: Bool { backgroundConfig.style != .none }
+
     /// Whether the editor has changes worth prompting about on close
     var hasUnsavedChanges: Bool {
-        !annotations.isEmpty || hasBeenCropped
+        !annotations.isEmpty || hasBeenCropped || hasBackground
     }
 
     // Cached CIContext for blur operations (expensive to create)
@@ -367,9 +370,15 @@ class AnnotationEditorState: ObservableObject {
         }
         
         image.unlockFocus()
+
+        // Apply background if configured
+        if backgroundConfig.style != .none {
+            return BackgroundRenderer.render(screenshot: image, config: backgroundConfig)
+        }
+
         return image
     }
-    
+
     private func applyBlur(_ blur: BlurAnnotation, in context: CGContext, imageSize: CGSize) {
         // Clip to blur bounds
         context.saveGState()

--- a/Shotter/Sources/Annotations/AnnotationEditorWindow.swift
+++ b/Shotter/Sources/Annotations/AnnotationEditorWindow.swift
@@ -385,7 +385,9 @@ struct AnnotationToolbar: View {
     let onSave: () -> Void
     let onCopy: () -> Void
     let onCancel: () -> Void
-    
+
+    @State private var showBackgroundPanel = false
+
     var body: some View {
         HStack(spacing: 12) {
             // Tool buttons
@@ -404,9 +406,17 @@ struct AnnotationToolbar: View {
                 RoundedRectangle(cornerRadius: 8)
                     .fill(Color(NSColor.controlBackgroundColor))
             )
-            
+
+            // Background button
+            HoverIconButton(icon: "rectangle.inset.filled", tooltip: "Background") {
+                showBackgroundPanel.toggle()
+            }
+            .popover(isPresented: $showBackgroundPanel) {
+                BackgroundPanel(state: state)
+            }
+
             Spacer()
-            
+
             // Undo/Redo
             HStack(spacing: 4) {
                 HoverIconButton(icon: "arrow.uturn.backward", tooltip: "Undo (⌘Z)", action: { state.undo() })
@@ -552,6 +562,139 @@ struct HoverIconButton: View {
             return Color.gray.opacity(0.2)
         }
         return Color.clear
+    }
+}
+
+// MARK: - Background Panel
+
+struct BackgroundPanel: View {
+    @ObservedObject var state: AnnotationEditorState
+
+    private let presets: [(String, BackgroundStyle)] = [
+        ("None", .none),
+        ("White", .solid(.white)),
+        ("Dark", .solid(NSColor(white: 0.1, alpha: 1))),
+        ("Blue Gradient", .gradient(.systemBlue, .systemPurple, .diagonal)),
+        ("Sunset", .gradient(.systemOrange, .systemPink, .diagonal)),
+        ("Ocean", .gradient(.systemTeal, .systemBlue, .vertical)),
+        ("Forest", .gradient(.systemGreen, .systemTeal, .diagonal)),
+    ]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Background")
+                .font(.headline)
+
+            // Preset grid
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 44))], spacing: 8) {
+                ForEach(presets.indices, id: \.self) { index in
+                    let preset = presets[index]
+                    BackgroundPresetSwatch(
+                        name: preset.0,
+                        style: preset.1,
+                        isSelected: state.backgroundConfig.style == preset.1
+                    ) {
+                        state.backgroundConfig.style = preset.1
+                    }
+                }
+            }
+
+            Divider()
+
+            // Padding slider
+            HStack {
+                Text("Padding")
+                    .frame(width: 55, alignment: .leading)
+                Slider(value: $state.backgroundConfig.padding, in: 20...120)
+                Text("\(Int(state.backgroundConfig.padding))")
+                    .frame(width: 30, alignment: .trailing)
+                    .monospacedDigit()
+            }
+
+            // Corner radius slider
+            HStack {
+                Text("Corners")
+                    .frame(width: 55, alignment: .leading)
+                Slider(value: $state.backgroundConfig.cornerRadius, in: 0...32)
+                Text("\(Int(state.backgroundConfig.cornerRadius))")
+                    .frame(width: 30, alignment: .trailing)
+                    .monospacedDigit()
+            }
+
+            // Shadow toggle
+            Toggle("Shadow", isOn: $state.backgroundConfig.shadowEnabled)
+        }
+        .padding()
+        .frame(width: 240)
+    }
+}
+
+struct BackgroundPresetSwatch: View {
+    let name: String
+    let style: BackgroundStyle
+    let isSelected: Bool
+    let action: () -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: action) {
+            RoundedRectangle(cornerRadius: 6)
+                .fill(swatchFill)
+                .frame(width: 44, height: 44)
+                .overlay(
+                    Group {
+                        if style == .none {
+                            Image(systemName: "xmark")
+                                .font(.system(size: 12))
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .stroke(isSelected ? Color.accentColor : Color.gray.opacity(0.3), lineWidth: isSelected ? 2 : 1)
+                )
+        }
+        .buttonStyle(.plain)
+        .scaleEffect(isHovered ? 1.1 : 1.0)
+        .animation(.easeInOut(duration: 0.15), value: isHovered)
+        .onHover { hovering in
+            isHovered = hovering
+        }
+        .help(name)
+        .accessibilityLabel(Text(name))
+        .accessibilityValue(Text(isSelected ? "Selected" : "Not selected"))
+    }
+
+    private var swatchFill: some ShapeStyle {
+        switch style {
+        case .none:
+            return AnyShapeStyle(Color(NSColor.controlBackgroundColor))
+        case .solid(let color):
+            return AnyShapeStyle(Color(color))
+        case .gradient(let start, let end, let direction):
+            let startPoint: UnitPoint
+            let endPoint: UnitPoint
+            switch direction {
+            case .horizontal:
+                startPoint = .leading
+                endPoint = .trailing
+            case .vertical:
+                startPoint = .top
+                endPoint = .bottom
+            case .diagonal:
+                startPoint = .topLeading
+                endPoint = .bottomTrailing
+            }
+            return AnyShapeStyle(
+                LinearGradient(
+                    colors: [Color(start), Color(end)],
+                    startPoint: startPoint,
+                    endPoint: endPoint
+                )
+            )
+        }
     }
 }
 

--- a/Shotter/Sources/Annotations/BackgroundRenderer.swift
+++ b/Shotter/Sources/Annotations/BackgroundRenderer.swift
@@ -1,0 +1,192 @@
+import AppKit
+
+// MARK: - Background Types
+
+enum GradientDirection: String, CaseIterable {
+    case horizontal
+    case vertical
+    case diagonal
+
+    var displayName: String {
+        switch self {
+        case .horizontal: return "Horizontal"
+        case .vertical: return "Vertical"
+        case .diagonal: return "Diagonal"
+        }
+    }
+}
+
+enum BackgroundStyle: Equatable {
+    case none
+    case solid(NSColor)
+    case gradient(NSColor, NSColor, GradientDirection)
+}
+
+struct BackgroundConfig: Equatable {
+    var style: BackgroundStyle = .none
+    var padding: CGFloat = 60
+    var cornerRadius: CGFloat = 12
+    var shadowEnabled: Bool = true
+    var shadowRadius: CGFloat = 20
+}
+
+// MARK: - Background Renderer
+
+struct BackgroundRenderer {
+    /// Renders the screenshot on a decorative background with padding, corner radius, and optional shadow.
+    static func render(screenshot: NSImage, config: BackgroundConfig) -> NSImage {
+        let screenshotSize = screenshot.size
+
+        // If no background style, just apply corner radius if needed
+        if config.style == .none {
+            if config.cornerRadius > 0 {
+                return applyCornerRadius(to: screenshot, radius: config.cornerRadius)
+            }
+            return screenshot
+        }
+
+        let outputSize = NSSize(
+            width: screenshotSize.width + config.padding * 2,
+            height: screenshotSize.height + config.padding * 2
+        )
+
+        let image = NSImage(size: outputSize)
+        image.lockFocus()
+
+        guard let context = NSGraphicsContext.current?.cgContext else {
+            image.unlockFocus()
+            return screenshot
+        }
+
+        let fullRect = CGRect(origin: .zero, size: outputSize)
+
+        // 1. Fill background
+        switch config.style {
+        case .none:
+            break
+        case .solid(let color):
+            context.setFillColor(color.cgColor)
+            context.fill(fullRect)
+        case .gradient(let startColor, let endColor, let direction):
+            drawGradient(
+                in: context,
+                rect: fullRect,
+                startColor: startColor,
+                endColor: endColor,
+                direction: direction
+            )
+        }
+
+        // 2. Calculate screenshot rect (centered)
+        let screenshotRect = CGRect(
+            x: config.padding,
+            y: config.padding,
+            width: screenshotSize.width,
+            height: screenshotSize.height
+        )
+
+        // 3. Draw shadow if enabled
+        if config.shadowEnabled {
+            context.saveGState()
+            let shadowColor = NSColor.black.withAlphaComponent(0.4).cgColor
+            context.setShadow(
+                offset: CGSize(width: 0, height: -4),
+                blur: config.shadowRadius,
+                color: shadowColor
+            )
+            // Draw a filled rounded rect to cast the shadow
+            let shadowPath = CGPath(
+                roundedRect: screenshotRect,
+                cornerWidth: config.cornerRadius,
+                cornerHeight: config.cornerRadius,
+                transform: nil
+            )
+            context.setFillColor(NSColor.black.cgColor)
+            context.addPath(shadowPath)
+            context.fillPath()
+            context.restoreGState()
+        }
+
+        // 4. Draw screenshot with corner radius clipping
+        context.saveGState()
+        if config.cornerRadius > 0 {
+            let clipPath = CGPath(
+                roundedRect: screenshotRect,
+                cornerWidth: config.cornerRadius,
+                cornerHeight: config.cornerRadius,
+                transform: nil
+            )
+            context.addPath(clipPath)
+            context.clip()
+        }
+        screenshot.draw(in: screenshotRect)
+        context.restoreGState()
+
+        image.unlockFocus()
+        return image
+    }
+
+    // MARK: - Helpers
+
+    private static func drawGradient(
+        in context: CGContext,
+        rect: CGRect,
+        startColor: NSColor,
+        endColor: NSColor,
+        direction: GradientDirection
+    ) {
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        guard let gradient = CGGradient(
+            colorsSpace: colorSpace,
+            colors: [startColor.cgColor, endColor.cgColor] as CFArray,
+            locations: [0.0, 1.0]
+        ) else { return }
+
+        let startPoint: CGPoint
+        let endPoint: CGPoint
+
+        switch direction {
+        case .horizontal:
+            startPoint = CGPoint(x: rect.minX, y: rect.midY)
+            endPoint = CGPoint(x: rect.maxX, y: rect.midY)
+        case .vertical:
+            startPoint = CGPoint(x: rect.midX, y: rect.minY)
+            endPoint = CGPoint(x: rect.midX, y: rect.maxY)
+        case .diagonal:
+            startPoint = CGPoint(x: rect.minX, y: rect.minY)
+            endPoint = CGPoint(x: rect.maxX, y: rect.maxY)
+        }
+
+        context.drawLinearGradient(
+            gradient,
+            start: startPoint,
+            end: endPoint,
+            options: [.drawsBeforeStartLocation, .drawsAfterEndLocation]
+        )
+    }
+
+    private static func applyCornerRadius(to image: NSImage, radius: CGFloat) -> NSImage {
+        let size = image.size
+        let result = NSImage(size: size)
+        result.lockFocus()
+
+        guard let context = NSGraphicsContext.current?.cgContext else {
+            result.unlockFocus()
+            return image
+        }
+
+        let rect = CGRect(origin: .zero, size: size)
+        let clipPath = CGPath(
+            roundedRect: rect,
+            cornerWidth: radius,
+            cornerHeight: radius,
+            transform: nil
+        )
+        context.addPath(clipPath)
+        context.clip()
+        image.draw(in: rect)
+
+        result.unlockFocus()
+        return result
+    }
+}


### PR DESCRIPTION
## Summary
Closes #32 (Phase 1: Background customization)

- Adds `BackgroundRenderer` with support for solid colors, gradients, and configurable padding/corner radius/shadow
- Adds `BackgroundConfig` and `BackgroundStyle` types with preset backgrounds (None, White, Dark, Blue Gradient, Sunset, Ocean, Forest)
- Adds background popover panel to annotation editor toolbar with:
  - Preset background grid
  - Padding slider (20-120pt)
  - Corner radius slider (0-32pt)
  - Shadow toggle
- Background is applied at render/export time, not during editing (performance)

## Test plan
- [ ] Open annotation editor and click the background button
- [ ] Select a preset background and verify it appears in the exported image
- [ ] Adjust padding slider and verify spacing changes
- [ ] Adjust corner radius and verify rounded corners on screenshot
- [ ] Toggle shadow on/off
- [ ] Verify background doesn't affect annotation placement during editing
- [ ] Save/copy with background applied and verify output

https://claude.ai/code/session_01FjXdHBaU5S1RoqxX4yHYNx