### PR TITLE
Add zoom controls to annotation editor

### DIFF
--- a/Shotter/Sources/Annotations/AnnotationCanvasView.swift
+++ b/Shotter/Sources/Annotations/AnnotationCanvasView.swift
@@ -161,9 +161,23 @@ class AnnotationCanvasView: NSView {
     private func imageRectInView() -> CGRect {
         guard let state = state else { return .zero }
 
-        let imageRect = annotationImageRect(in: bounds.size, imageSize: state.imageSize)
-        scale = imageRect.width / state.imageSize.width
-        return imageRect
+        if state.zoomLevel == 0 {
+            // Fit to window (existing behavior)
+            let imageRect = annotationImageRect(in: bounds.size, imageSize: state.imageSize)
+            scale = imageRect.width / state.imageSize.width
+            return imageRect
+        } else {
+            // Custom zoom level
+            let zoomedWidth = state.imageSize.width * state.zoomLevel
+            let zoomedHeight = state.imageSize.height * state.zoomLevel
+            scale = state.zoomLevel
+
+            // Center the image, then apply pan offset
+            let x = (bounds.width - zoomedWidth) / 2 + state.panOffset.x
+            let y = (bounds.height - zoomedHeight) / 2 + state.panOffset.y
+
+            return CGRect(x: x, y: y, width: zoomedWidth, height: zoomedHeight)
+        }
     }
     
     private func drawCheckerboard(in rect: CGRect, context: CGContext) {
@@ -359,6 +373,32 @@ class AnnotationCanvasView: NSView {
         NSCursor.arrow.set()
     }
     
+    // MARK: - Scroll & Zoom Gestures
+
+    override func scrollWheel(with event: NSEvent) {
+        guard let state = state, state.zoomLevel > 0 else {
+            super.scrollWheel(with: event)
+            return
+        }
+
+        // Pan the view
+        state.panOffset.x += event.scrollingDeltaX
+        state.panOffset.y -= event.scrollingDeltaY
+        needsDisplay = true
+    }
+
+    override func magnify(with event: NSEvent) {
+        guard let state = state else { return }
+
+        if state.zoomLevel == 0 {
+            state.zoomLevel = imageRectInView().width / state.imageSize.width
+        }
+
+        let newZoom = state.zoomLevel * (1 + event.magnification)
+        state.zoomLevel = max(0.25, min(5.0, newZoom))
+        needsDisplay = true
+    }
+
     // MARK: - Keyboard Events
     
     override func keyDown(with event: NSEvent) {

--- a/Shotter/Sources/Annotations/AnnotationEditorState.swift
+++ b/Shotter/Sources/Annotations/AnnotationEditorState.swift
@@ -17,6 +17,8 @@ class AnnotationEditorState: ObservableObject {
     @Published var nextCounterNumber: Int = 1
     @Published var cropRect: CGRect? = nil
     @Published private(set) var canvasFocusRequestID: Int = 0
+    @Published var zoomLevel: CGFloat = 0 // 0 means "fit to window"
+    @Published var panOffset: CGPoint = .zero
 
     // Modifier keys
     var isShiftKeyHeld: Bool = false
@@ -335,6 +337,32 @@ class AnnotationEditorState: ObservableObject {
         setTool(.select)
     }
 
+    // MARK: - Zoom
+
+    func zoomIn() {
+        if zoomLevel == 0 {
+            zoomLevel = 1.0
+        }
+        zoomLevel = min(zoomLevel * 1.5, 5.0)
+        // Don't reset panOffset - user may want to stay in same area
+    }
+
+    func zoomOut() {
+        zoomLevel = max(zoomLevel / 1.5, 0.25)
+    }
+
+    func zoomToFit() {
+        zoomLevel = 0
+        panOffset = .zero
+    }
+
+    func zoomTo(_ level: CGFloat) {
+        zoomLevel = level
+        if level == 0 {
+            panOffset = .zero
+        }
+    }
+
     // MARK: - Rendering
     
     /// Render the final image with all annotations
@@ -430,6 +458,15 @@ extension AnnotationEditorState {
                 if selectedAnnotationId == nil, let first = annotations.first {
                     selectAnnotation(first.id)
                 }
+                return true
+            case "=", "+":
+                zoomIn()
+                return true
+            case "-":
+                zoomOut()
+                return true
+            case "0":
+                zoomToFit()
                 return true
             default:
                 break

--- a/Shotter/Sources/Annotations/AnnotationEditorWindow.swift
+++ b/Shotter/Sources/Annotations/AnnotationEditorWindow.swift
@@ -664,6 +664,40 @@ struct ToolOptionsBar: View {
 
             Spacer()
 
+            // Zoom controls
+            HStack(spacing: 4) {
+                Button(action: { state.zoomOut() }) {
+                    Image(systemName: "minus.magnifyingglass")
+                        .font(.system(size: 12))
+                }
+                .buttonStyle(.plain)
+                .help("Zoom Out (\u{2318}-)")
+
+                // Zoom level picker
+                Picker("", selection: Binding(
+                    get: { closestZoomLevel(state.zoomLevel) },
+                    set: { state.zoomTo($0) }
+                )) {
+                    Text("Fit").tag(CGFloat(0))
+                    Text("50%").tag(CGFloat(0.5))
+                    Text("100%").tag(CGFloat(1.0))
+                    Text("150%").tag(CGFloat(1.5))
+                    Text("200%").tag(CGFloat(2.0))
+                }
+                .pickerStyle(.menu)
+                .frame(width: 65)
+
+                Button(action: { state.zoomIn() }) {
+                    Image(systemName: "plus.magnifyingglass")
+                        .font(.system(size: 12))
+                }
+                .buttonStyle(.plain)
+                .help("Zoom In (\u{2318}+)")
+            }
+
+            Divider()
+                .frame(height: 20)
+
             // Keyboard shortcut hints (always visible)
             Text(keyboardHint)
                 .font(.caption2)
@@ -673,6 +707,12 @@ struct ToolOptionsBar: View {
         .padding(.vertical, 8)
         .frame(height: 44)
         .background(Color(NSColor.windowBackgroundColor))
+    }
+
+    private func closestZoomLevel(_ value: CGFloat) -> CGFloat {
+        if value == 0 { return 0 }
+        let levels: [CGFloat] = [0.5, 1.0, 1.5, 2.0]
+        return levels.min(by: { abs($0 - value) < abs($1 - value) }) ?? 1.0
     }
 
     private func closestStrokeSize(_ value: CGFloat) -> CGFloat {


### PR DESCRIPTION
## Summary
- Adds zoom level state (`zoomLevel`, `panOffset`) to `AnnotationEditorState`
- Zoom percentage dropdown in bottom bar (Fit / 50% / 100% / 150% / 200%)
- Keyboard shortcuts: `Cmd+=` zoom in, `Cmd+-` zoom out, `Cmd+0` fit to window
- Scroll wheel panning when zoomed in
- Pinch-to-zoom trackpad gesture support
- Leverages existing `scale`/`offset` infrastructure in `AnnotationCanvasView`

## Test plan
- [ ] Open annotation editor, verify default "Fit" mode works as before
- [ ] Use dropdown to switch between zoom levels (50%, 100%, 150%, 200%)
- [ ] Verify Cmd+/Cmd- keyboard shortcuts work
- [ ] Verify scroll wheel pans the image when zoomed in
- [ ] Verify pinch-to-zoom gesture works on trackpad
- [ ] Verify annotations are placed correctly at different zoom levels
- [ ] Verify Cmd+0 resets to fit-to-window mode

Closes #31

https://claude.ai/code/session_01EUZV2oHcXJBoZ6aQRWzy9R