### PR TITLE
Auto-annotate screenshots with timestamp and app name

### DIFF
--- a/Shotter/Sources/App/ShotterApp.swift
+++ b/Shotter/Sources/App/ShotterApp.swift
@@ -137,6 +137,19 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private func handleCapture(_ image: NSImage, preferredScreen: NSScreen? = nil, directCopy: Bool = false) {
         let prefs = PreferencesManager.shared
 
+        // Apply timestamp overlay if enabled
+        let processedImage: NSImage
+        if prefs.timestampOverlayEnabled {
+            let frontmostApp = NSWorkspace.shared.frontmostApplication?.localizedName
+            processedImage = TimestampOverlay.apply(
+                to: image,
+                appName: frontmostApp,
+                position: prefs.timestampOverlayPosition
+            )
+        } else {
+            processedImage = image
+        }
+
         // Direct-copy mode: Option held + auto-copy is OFF → copy and skip overlay
         let shouldDirectCopy = directCopy && !prefs.autoCopyToClipboard
 
@@ -149,7 +162,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let result: Result<URL, SaveError>?
         let savedURL: URL?
         if prefs.autoSaveScreenshots {
-            result = saveImage(image)
+            result = saveImage(processedImage)
             savedURL = try? result?.get()
         } else {
             result = nil
@@ -160,7 +173,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Now includes file URL for terminal compatibility (Ghostty, etc.)
         if prefs.autoCopyToClipboard || shouldDirectCopy {
             DispatchQueue.main.async {
-                self.copyToClipboard(image, fileURL: savedURL)
+                self.copyToClipboard(processedImage, fileURL: savedURL)
             }
         }
 
@@ -174,7 +187,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         DispatchQueue.main.async {
             // When auto-save is disabled (no result), show overlay with save functionality
             if result == nil {
-                self.showOverlayWithManualSave(image: image, preferredScreen: preferredScreen)
+                self.showOverlayWithManualSave(image: processedImage, preferredScreen: preferredScreen)
                 return
             }
 
@@ -182,11 +195,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             switch result! {
             case .success(let savedURL):
                 self.overlayController?.showOverlay(
-                    image: image,
+                    image: processedImage,
                     savedURL: savedURL,
                     preferredScreen: preferredScreen,
                     onCopy: {
-                        self.copyToClipboard(image, fileURL: savedURL)
+                        self.copyToClipboard(processedImage, fileURL: savedURL)
                     },
                     onSave: {
                         NSWorkspace.shared.activateFileViewerSelecting([savedURL])
@@ -194,7 +207,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                     onAnnotate: {
                         DebugLogger.log("Overlay annotate clicked (savedURL available)")
                         self.overlayController?.dismissOverlay()
-                        self.openAnnotationEditor(image: image, savedURL: savedURL, preferredScreen: preferredScreen)
+                        self.openAnnotationEditor(image: processedImage, savedURL: savedURL, preferredScreen: preferredScreen)
                     },
                     onDelete: {
                         self.moveToTrash(savedURL)
@@ -203,7 +216,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             case .failure(let error):
                 self.showSaveErrorAlert(error: error)
                 // Auto-save failed - show overlay with manual save option to retry
-                self.showOverlayWithManualSave(image: image, preferredScreen: preferredScreen)
+                self.showOverlayWithManualSave(image: processedImage, preferredScreen: preferredScreen)
             }
         }
     }

--- a/Shotter/Sources/Preferences/PreferencesManager.swift
+++ b/Shotter/Sources/Preferences/PreferencesManager.swift
@@ -6,6 +6,23 @@ import os.log
 
 private let logger = Logger(subsystem: "com.densign.shotter", category: "Preferences")
 
+/// Corner position for timestamp overlay on screenshots
+enum OverlayCorner: String, CaseIterable {
+    case topLeft = "topLeft"
+    case topRight = "topRight"
+    case bottomLeft = "bottomLeft"
+    case bottomRight = "bottomRight"
+
+    var displayName: String {
+        switch self {
+        case .topLeft: return "Top Left"
+        case .topRight: return "Top Right"
+        case .bottomLeft: return "Bottom Left"
+        case .bottomRight: return "Bottom Right"
+        }
+    }
+}
+
 /// Position for the screenshot overlay
 enum OverlayPosition: String, CaseIterable {
     case bottomLeft = "bottomLeft"
@@ -96,6 +113,8 @@ class PreferencesManager: ObservableObject {
         static let shortcutArea = "shortcutArea"
         static let shortcutWindow = "shortcutWindow"
         static let overlayPosition = "overlayPosition"
+        static let timestampOverlayEnabled = "timestampOverlayEnabled"
+        static let timestampOverlayPosition = "timestampOverlayPosition"
     }
     
     @Published var saveLocation: URL {
@@ -167,6 +186,14 @@ class PreferencesManager: ObservableObject {
         }
     }
 
+    @Published var timestampOverlayEnabled: Bool {
+        didSet { defaults.set(timestampOverlayEnabled, forKey: Keys.timestampOverlayEnabled) }
+    }
+
+    @Published var timestampOverlayPosition: OverlayCorner {
+        didSet { defaults.set(timestampOverlayPosition.rawValue, forKey: Keys.timestampOverlayPosition) }
+    }
+
     private func saveShortcut(_ config: ShortcutConfig, forKey key: String) {
         if let data = try? JSONEncoder().encode(config) {
             defaults.set(data, forKey: key)
@@ -235,6 +262,16 @@ class PreferencesManager: ObservableObject {
             overlayPosition = position
         } else {
             overlayPosition = .bottomLeft
+        }
+
+        // Load timestamp overlay preferences
+        timestampOverlayEnabled = defaults.bool(forKey: Keys.timestampOverlayEnabled)
+
+        if let posStr = defaults.string(forKey: Keys.timestampOverlayPosition),
+           let corner = OverlayCorner(rawValue: posStr) {
+            timestampOverlayPosition = corner
+        } else {
+            timestampOverlayPosition = .bottomLeft
         }
 
         defaults.set(actualLaunchAtLogin, forKey: Keys.launchAtLogin)

--- a/Shotter/Sources/Preferences/PreferencesView.swift
+++ b/Shotter/Sources/Preferences/PreferencesView.swift
@@ -65,7 +65,26 @@ struct PreferencesView: View {
             } header: {
                 Text("General")
             }
-            
+
+            Section {
+                Toggle("Add timestamp overlay to screenshots", isOn: $prefs.timestampOverlayEnabled)
+
+                if prefs.timestampOverlayEnabled {
+                    HStack {
+                        Text("Overlay position:")
+                        Spacer()
+                        Picker("", selection: $prefs.timestampOverlayPosition) {
+                            ForEach(OverlayCorner.allCases, id: \.self) { corner in
+                                Text(corner.displayName).tag(corner)
+                            }
+                        }
+                        .frame(width: 120)
+                    }
+                }
+            } header: {
+                Text("Screenshot Overlay")
+            }
+
             Section {
                 ShortcutRow(
                     label: "Fullscreen",

--- a/Shotter/Sources/Utils/TimestampOverlay.swift
+++ b/Shotter/Sources/Utils/TimestampOverlay.swift
@@ -1,0 +1,81 @@
+import AppKit
+import Foundation
+
+struct TimestampOverlay {
+    /// Renders a timestamp and optional app name overlay onto an image
+    static func apply(
+        to image: NSImage,
+        appName: String? = nil,
+        position: OverlayCorner = .bottomLeft
+    ) -> NSImage {
+        let size = image.size
+        let result = NSImage(size: size)
+        result.lockFocus()
+
+        // Draw original image
+        image.draw(in: CGRect(origin: .zero, size: size))
+
+        guard let _ = NSGraphicsContext.current else {
+            result.unlockFocus()
+            return image
+        }
+
+        // Format timestamp
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        let timestamp = formatter.string(from: Date())
+
+        // Build label text
+        var label = timestamp
+        if let appName = appName, !appName.isEmpty {
+            label = "\(appName)  \u{2022}  \(timestamp)"
+        }
+
+        // Calculate font size based on image dimensions (auto-scale)
+        let baseFontSize = max(11, min(size.width, size.height) * 0.018)
+        let font = NSFont.monospacedSystemFont(ofSize: baseFontSize, weight: .medium)
+
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: font,
+            .foregroundColor: NSColor.white
+        ]
+        let textSize = (label as NSString).size(withAttributes: attributes)
+
+        let padding: CGFloat = baseFontSize * 0.6
+        let badgeWidth = textSize.width + padding * 2
+        let badgeHeight = textSize.height + padding
+        let cornerInset: CGFloat = baseFontSize * 0.8
+
+        // Position badge based on corner preference
+        let badgeOrigin: CGPoint
+        switch position {
+        case .topLeft:
+            badgeOrigin = CGPoint(x: cornerInset, y: size.height - badgeHeight - cornerInset)
+        case .topRight:
+            badgeOrigin = CGPoint(x: size.width - badgeWidth - cornerInset, y: size.height - badgeHeight - cornerInset)
+        case .bottomLeft:
+            badgeOrigin = CGPoint(x: cornerInset, y: cornerInset)
+        case .bottomRight:
+            badgeOrigin = CGPoint(x: size.width - badgeWidth - cornerInset, y: cornerInset)
+        }
+
+        let badgeRect = CGRect(origin: badgeOrigin, size: CGSize(width: badgeWidth, height: badgeHeight))
+
+        // Draw semi-transparent background
+        let bgPath = NSBezierPath(roundedRect: badgeRect, xRadius: 4, yRadius: 4)
+        NSColor.black.withAlphaComponent(0.55).setFill()
+        bgPath.fill()
+
+        // Draw text centered in badge
+        let textRect = CGRect(
+            x: badgeRect.origin.x + padding,
+            y: badgeRect.origin.y + (badgeHeight - textSize.height) / 2,
+            width: textSize.width,
+            height: textSize.height
+        )
+        (label as NSString).draw(in: textRect, withAttributes: attributes)
+
+        result.unlockFocus()
+        return result
+    }
+}


### PR DESCRIPTION
## Summary
- Adds optional timestamp + app name overlay on captured screenshots
- New `TimestampOverlay` utility renders a semi-transparent badge with date/time and active app name
- Font size auto-scales based on screenshot dimensions
- Configurable overlay position (top-left, top-right, bottom-left, bottom-right)
- Toggle in Preferences under new "Screenshot Overlay" section
- Disabled by default so existing behavior is unchanged

## Test plan
- [ ] Enable "Add timestamp overlay" in Preferences
- [ ] Capture a screenshot and verify timestamp badge appears
- [ ] Verify app name is included in the overlay
- [ ] Test all 4 corner positions
- [ ] Verify font scales appropriately for different screenshot sizes
- [ ] Verify overlay is disabled by default on fresh install
- [ ] Verify overlay renders correctly in annotation editor

Closes #27

https://claude.ai/code/session_01EUZV2oHcXJBoZ6aQRWzy9R