### PR TITLE
Add scrolling capture UI with menu item and shortcut

### DIFF
--- a/Shotter/Sources/App/ShotterApp.swift
+++ b/Shotter/Sources/App/ShotterApp.swift
@@ -51,6 +51,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             onCaptureFullscreen: { [weak self] in self?.captureFullscreen() },
             onCaptureArea: { [weak self] in self?.captureArea() },
             onCaptureWindow: { [weak self] in self?.captureWindow() },
+            onCaptureScrolling: { [weak self] in self?.captureScrolling() },
             onCaptureDisplay: { [weak self] display in self?.captureDisplay(display) },
             onOpenSaveFolder: { self.openSaveFolder() },
             onOpenPreferences: { self.openPreferences() },
@@ -124,6 +125,16 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
     
+    private func captureScrolling() {
+        Task {
+            guard let result = await captureEngine?.captureScrolling() else {
+                logger.info("Scrolling capture returned nil (user cancelled or failed)")
+                return
+            }
+            handleCapture(result.image, preferredScreen: result.preferredScreen)
+        }
+    }
+
     private func captureDisplay(_ display: CaptureDisplay) {
         Task {
             guard let result = await captureEngine?.captureDisplay(display) else {

--- a/Shotter/Sources/Capture/CaptureEngine.swift
+++ b/Shotter/Sources/Capture/CaptureEngine.swift
@@ -444,6 +444,56 @@ class CaptureEngine {
         return await captureWindow(window)
     }
 
+    // MARK: - Scrolling Capture
+
+    func captureScrolling() async -> CaptureResult? {
+        await refreshAvailableContent()
+        let windows = await getAvailableWindows()
+
+        guard let selection = await showWindowSelectorForScrolling(windows: windows) else {
+            return nil
+        }
+
+        let session = ScrollingCaptureSession(
+            selection: selection,
+            captureWindow: { [weak self] window in
+                guard let result = await self?.captureWindow(window) else { return nil }
+                return result.image
+            }
+        )
+
+        guard let image = await session.capture() else {
+            return nil
+        }
+
+        let windowCenter = CGPoint(x: selection.window.frame.midX, y: selection.window.frame.midY)
+        let mainScreenHeight = NSScreen.screens.first?.frame.height ?? 0
+        let cocoaCenter = NSPoint(x: windowCenter.x, y: mainScreenHeight - windowCenter.y)
+        let containingScreen = NSScreen.screens.first { $0.frame.contains(cocoaCenter) }
+
+        return CaptureResult(image: image, preferredScreen: containingScreen)
+    }
+
+    @MainActor
+    private func showWindowSelectorForScrolling(windows: [SCWindow]) async -> WindowSelectionResult? {
+        return await withCheckedContinuation { continuation in
+            let selector = WindowSelectorController(windows: windows) { [weak self] window in
+                self?.activeWindowSelector = nil
+                if let window = window {
+                    let clickPoint = NSPoint(
+                        x: window.frame.midX,
+                        y: window.frame.midY
+                    )
+                    continuation.resume(returning: WindowSelectionResult(window: window, clickPoint: clickPoint))
+                } else {
+                    continuation.resume(returning: nil)
+                }
+            }
+            self.activeWindowSelector = selector
+            selector.show()
+        }
+    }
+
     // MARK: - Selectors
 
     @MainActor

--- a/Shotter/Sources/MenuBar/MenuBarController.swift
+++ b/Shotter/Sources/MenuBar/MenuBarController.swift
@@ -7,16 +7,18 @@ class MenuBarController: NSObject {
     private let onCaptureFullscreen: () -> Void
     private let onCaptureArea: () -> Void
     private let onCaptureWindow: () -> Void
+    private let onCaptureScrolling: () -> Void
     private let onCaptureDisplay: (CaptureDisplay) -> Void
     private let onOpenSaveFolder: () -> Void
     private let onOpenPreferences: () -> Void
     private let onQuit: () -> Void
     private let getDisplays: () async -> [CaptureDisplay]
-    
+
     init(
         onCaptureFullscreen: @escaping () -> Void,
         onCaptureArea: @escaping () -> Void,
         onCaptureWindow: @escaping () -> Void,
+        onCaptureScrolling: @escaping () -> Void,
         onCaptureDisplay: @escaping (CaptureDisplay) -> Void,
         onOpenSaveFolder: @escaping () -> Void,
         onOpenPreferences: @escaping () -> Void,
@@ -26,6 +28,7 @@ class MenuBarController: NSObject {
         self.onCaptureFullscreen = onCaptureFullscreen
         self.onCaptureArea = onCaptureArea
         self.onCaptureWindow = onCaptureWindow
+        self.onCaptureScrolling = onCaptureScrolling
         self.onCaptureDisplay = onCaptureDisplay
         self.onOpenSaveFolder = onOpenSaveFolder
         self.onOpenPreferences = onOpenPreferences
@@ -82,7 +85,17 @@ class MenuBarController: NSObject {
         windowItem.keyEquivalent = "5"
         windowItem.target = self
         menu.addItem(windowItem)
-        
+
+        let scrollingItem = NSMenuItem(
+            title: "Capture Scrolling...",
+            action: #selector(captureScrollingClicked),
+            keyEquivalent: ""
+        )
+        scrollingItem.keyEquivalentModifierMask = [.command, .shift]
+        scrollingItem.keyEquivalent = "6"
+        scrollingItem.target = self
+        menu.addItem(scrollingItem)
+
         menu.addItem(NSMenuItem.separator())
         
         // Capture Display submenu (populated dynamically)
@@ -160,6 +173,10 @@ class MenuBarController: NSObject {
     
     @objc private func captureWindowClicked() {
         onCaptureWindow()
+    }
+
+    @objc private func captureScrollingClicked() {
+        onCaptureScrolling()
     }
     
     @objc private func captureDisplayClicked(_ sender: NSMenuItem) {


### PR DESCRIPTION
## Summary
- Wires the existing `ScrollingCaptureSession` into the app UI
- Adds "Capture Scrolling..." menu item with `Cmd+Shift+6` shortcut
- User selects a window, then auto-scrolling + stitching produces a tall image
- Result flows through standard `handleCapture` pipeline (overlay, save, annotate)
- New `captureScrolling()` method on `CaptureEngine` orchestrates the flow

## Test plan
- [ ] Verify "Capture Scrolling..." appears in menu bar dropdown
- [ ] Click menu item, select a window with scrollable content
- [ ] Verify scrolling capture produces a stitched tall image
- [ ] Verify the result appears in the quick access overlay
- [ ] Verify the result can be annotated and saved
- [ ] Verify cancelling window selection returns gracefully
- [ ] Test with non-scrollable window (should return single capture)

Closes #35

https://claude.ai/code/session_01EUZV2oHcXJBoZ6aQRWzy9R