### PR TITLE
AI auto-redact sensitive data and screenshot search indexing

### DIFF
--- a/Shotter/Sources/AI/ScreenshotIndexer.swift
+++ b/Shotter/Sources/AI/ScreenshotIndexer.swift
@@ -1,0 +1,108 @@
+import CoreSpotlight
+import UniformTypeIdentifiers
+import Vision
+import AppKit
+import os.log
+
+private let indexerLogger = Logger(subsystem: "com.densign.shotter", category: "Indexer")
+
+class ScreenshotIndexer {
+    static let shared = ScreenshotIndexer()
+    private let domainID = "com.densign.shotter.screenshots"
+
+    private init() {}
+
+    /// Index a screenshot with OCR-extracted text for searchability
+    func indexScreenshot(at url: URL, appName: String? = nil) {
+        Task {
+            guard let image = NSImage(contentsOf: url),
+                  let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
+                indexerLogger.warning("Could not load image for indexing: \(url.path)")
+                return
+            }
+
+            // Run OCR
+            let text = await extractText(from: cgImage)
+
+            // Create searchable item
+            let attributeSet = CSSearchableItemAttributeSet(contentType: .image)
+            attributeSet.title = url.lastPathComponent
+            attributeSet.contentDescription = text
+            attributeSet.keywords = text.components(separatedBy: .whitespacesAndNewlines).filter { !$0.isEmpty }
+            attributeSet.creator = appName
+            attributeSet.contentCreationDate = Date()
+            attributeSet.thumbnailURL = url
+
+            let item = CSSearchableItem(
+                uniqueIdentifier: url.path,
+                domainIdentifier: domainID,
+                attributeSet: attributeSet
+            )
+            item.expirationDate = Calendar.current.date(byAdding: .year, value: 1, to: Date())
+
+            CSSearchableIndex.default().indexSearchableItems([item]) { error in
+                if let error = error {
+                    indexerLogger.error("Failed to index screenshot: \(error.localizedDescription)")
+                } else {
+                    indexerLogger.info("Indexed screenshot: \(url.lastPathComponent)")
+                }
+            }
+        }
+    }
+
+    /// Search indexed screenshots by text content
+    func search(query: String, limit: Int = 20) async -> [URL] {
+        await withCheckedContinuation { continuation in
+            let escapedQuery = query.replacingOccurrences(of: "\"", with: "\\\"")
+            let queryString = "contentDescription == \"*\(escapedQuery)*\"cd"
+            let searchQuery = CSSearchQuery(queryString: queryString, attributes: ["contentDescription"])
+
+            var results: [URL] = []
+
+            searchQuery.foundItemsHandler = { items in
+                let urls = items.prefix(limit).compactMap { item -> URL? in
+                    URL(fileURLWithPath: item.uniqueIdentifier)
+                }
+                results.append(contentsOf: urls)
+            }
+
+            searchQuery.completionHandler = { error in
+                if let error = error {
+                    indexerLogger.error("Search failed: \(error.localizedDescription)")
+                }
+                continuation.resume(returning: results)
+            }
+
+            searchQuery.start()
+        }
+    }
+
+    /// Remove a screenshot from the index
+    func removeFromIndex(at url: URL) {
+        CSSearchableIndex.default().deleteSearchableItems(withIdentifiers: [url.path]) { error in
+            if let error = error {
+                indexerLogger.error("Failed to remove from index: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    private func extractText(from cgImage: CGImage) async -> String {
+        let request = VNRecognizeTextRequest()
+        request.recognitionLevel = .accurate
+        request.usesLanguageCorrection = true
+
+        let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
+
+        do {
+            try handler.perform([request])
+        } catch {
+            return ""
+        }
+
+        guard let results = request.results else { return "" }
+
+        return results
+            .compactMap { $0.topCandidates(1).first?.string }
+            .joined(separator: " ")
+    }
+}

--- a/Shotter/Sources/AI/SensitiveDataDetector.swift
+++ b/Shotter/Sources/AI/SensitiveDataDetector.swift
@@ -1,0 +1,111 @@
+import Vision
+import AppKit
+
+struct SensitiveRegion {
+    let text: String
+    let category: SensitiveCategory
+    let bounds: CGRect // normalized 0-1 coordinates from Vision
+}
+
+enum SensitiveCategory: String, CaseIterable {
+    case email = "Email"
+    case apiKey = "API Key"
+    case phone = "Phone"
+    case creditCard = "Credit Card"
+    case ipAddress = "IP Address"
+    case ssn = "SSN"
+
+    var icon: String {
+        switch self {
+        case .email: return "envelope"
+        case .apiKey: return "key"
+        case .phone: return "phone"
+        case .creditCard: return "creditcard"
+        case .ipAddress: return "network"
+        case .ssn: return "person.text.rectangle"
+        }
+    }
+}
+
+class SensitiveDataDetector {
+    private static let patterns: [(SensitiveCategory, NSRegularExpression)] = {
+        let defs: [(SensitiveCategory, String)] = [
+            (.email, "[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}"),
+            (.apiKey, "(sk-[a-zA-Z0-9]{20,}|ghp_[a-zA-Z0-9]{36}|AKIA[0-9A-Z]{16})"),
+            (.phone, "\\+?[0-9]{1,3}[-.\\s]?\\(?[0-9]{3}\\)?[-.\\s]?[0-9]{3}[-.\\s]?[0-9]{4}"),
+            (.creditCard, "[0-9]{4}[-.\\s]?[0-9]{4}[-.\\s]?[0-9]{4}[-.\\s]?[0-9]{4}"),
+            (.ipAddress, "\\b[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\b"),
+            (.ssn, "\\b[0-9]{3}-[0-9]{2}-[0-9]{4}\\b"),
+        ]
+        return defs.compactMap { category, pattern in
+            guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
+            return (category, regex)
+        }
+    }()
+
+    /// Detect sensitive data in an image using Vision OCR + regex pattern matching
+    static func detect(in image: NSImage) async -> [SensitiveRegion] {
+        guard let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
+            return []
+        }
+
+        let request = VNRecognizeTextRequest()
+        request.recognitionLevel = .accurate
+        request.usesLanguageCorrection = true
+
+        let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
+
+        do {
+            try handler.perform([request])
+        } catch {
+            return []
+        }
+
+        guard let observations = request.results else { return [] }
+
+        var regions: [SensitiveRegion] = []
+
+        for observation in observations {
+            guard let candidate = observation.topCandidates(1).first else { continue }
+            let text = candidate.string
+
+            for (category, regex) in patterns {
+                let range = NSRange(text.startIndex..<text.endIndex, in: text)
+                let matches = regex.matches(in: text, range: range)
+
+                for match in matches {
+                    // Get the bounding box for the matched text range
+                    if let stringRange = Range(match.range, in: text),
+                       let boundingBox = try? candidate.boundingBox(for: stringRange) {
+                        let rect = boundingBox.boundingBox
+                        regions.append(SensitiveRegion(
+                            text: String(text[stringRange]),
+                            category: category,
+                            bounds: rect
+                        ))
+                    } else {
+                        // Fallback: use the whole observation bounding box
+                        regions.append(SensitiveRegion(
+                            text: String(text[Range(match.range, in: text)!]),
+                            category: category,
+                            bounds: observation.boundingBox
+                        ))
+                    }
+                }
+            }
+        }
+
+        return regions
+    }
+
+    /// Convert Vision normalized bounds (origin bottom-left, 0-1) to image pixel coordinates
+    static func convertToImageCoordinates(_ region: SensitiveRegion, imageSize: CGSize) -> CGRect {
+        let visionRect = region.bounds
+        return CGRect(
+            x: visionRect.origin.x * imageSize.width,
+            y: (1 - visionRect.origin.y - visionRect.height) * imageSize.height,
+            width: visionRect.width * imageSize.width,
+            height: visionRect.height * imageSize.height
+        )
+    }
+}

--- a/Shotter/Sources/Annotations/AnnotationEditorWindow.swift
+++ b/Shotter/Sources/Annotations/AnnotationEditorWindow.swift
@@ -606,7 +606,7 @@ struct ToolOptionsBar: View {
     var body: some View {
         HStack(spacing: 16) {
             // Tool-specific options (not for select, eraser, or crop tools)
-            if ![.select, .eraser, .crop].contains(state.currentToolType) {
+            if ![.select, .eraser, .crop, .autoRedact].contains(state.currentToolType) {
                 // Color swatches with selection ring and hover effect
                 HStack(spacing: 6) {
                     ForEach(presetColors, id: \.self) { color in
@@ -724,6 +724,8 @@ struct ToolOptionsBar: View {
             return "Drag to select crop area"
         case .textHighlight:
             return "Drag to highlight"
+        case .autoRedact:
+            return "Click to auto-detect and blur sensitive information"
         }
     }
 }

--- a/Shotter/Sources/Annotations/AnnotationTool.swift
+++ b/Shotter/Sources/Annotations/AnnotationTool.swift
@@ -14,7 +14,8 @@ enum AnnotationToolType: String, CaseIterable, Identifiable {
     case eraser = "Eraser"
     case crop = "Crop"
     case textHighlight = "Text Highlight"
-    
+    case autoRedact = "Auto-Redact"
+
     var id: String { rawValue }
     
     var icon: String {
@@ -30,9 +31,10 @@ enum AnnotationToolType: String, CaseIterable, Identifiable {
         case .eraser: return "eraser"
         case .crop: return "crop"
         case .textHighlight: return "highlighter"
+        case .autoRedact: return "eye.slash"
         }
     }
-    
+
     var tooltip: String {
         switch self {
         case .select: return "Select and move annotations (V)"
@@ -46,9 +48,10 @@ enum AnnotationToolType: String, CaseIterable, Identifiable {
         case .eraser: return "Click annotation to remove (X)"
         case .crop: return "Crop screenshot"
         case .textHighlight: return "Text Highlight (H)"
+        case .autoRedact: return "Auto-detect & blur sensitive info"
         }
     }
-    
+
     var shortcut: Character? {
         switch self {
         case .select: return "v"
@@ -62,6 +65,7 @@ enum AnnotationToolType: String, CaseIterable, Identifiable {
         case .eraser: return "x"
         case .crop: return nil
         case .textHighlight: return "h"
+        case .autoRedact: return nil
         }
     }
 }
@@ -634,6 +638,44 @@ class TextHighlightTool: AnnotationTool {
     }
 }
 
+// MARK: - Auto-Redact Tool
+
+class AutoRedactTool: AnnotationTool {
+    let toolType: AnnotationToolType = .autoRedact
+    var cursor: NSCursor { .arrow }
+
+    func mouseDown(at point: CGPoint, state: AnnotationEditorState) {
+        // Auto-redact is triggered on tool selection, not mouse click
+        // Run detection and add blur annotations
+        Task { @MainActor in
+            let regions = await SensitiveDataDetector.detect(in: state.baseImage)
+
+            guard !regions.isEmpty else {
+                // No sensitive data found - could show an alert
+                return
+            }
+
+            for region in regions {
+                let imageRect = SensitiveDataDetector.convertToImageCoordinates(region, imageSize: state.imageSize)
+
+                // Add some padding
+                let paddedRect = imageRect.insetBy(dx: -4, dy: -2)
+
+                // Create blur annotation for each detected region
+                var blur = BlurAnnotation(bounds: paddedRect, blurRadius: 20)
+                blur.isSelected = false
+                state.addAnnotation(blur)
+            }
+
+            // Switch to select tool after redacting
+            state.setTool(.select)
+        }
+    }
+
+    func mouseDragged(to point: CGPoint, state: AnnotationEditorState) {}
+    func mouseUp(at point: CGPoint, state: AnnotationEditorState) {}
+}
+
 // MARK: - Tool Factory
 
 struct AnnotationToolFactory {
@@ -650,6 +692,7 @@ struct AnnotationToolFactory {
         case .eraser: return EraserTool()
         case .crop: return CropTool()
         case .textHighlight: return TextHighlightTool()
+        case .autoRedact: return AutoRedactTool()
         }
     }
 }

--- a/Shotter/Sources/App/ShotterApp.swift
+++ b/Shotter/Sources/App/ShotterApp.swift
@@ -282,6 +282,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         do {
             try pngData.write(to: fileURL)
             logger.info("Screenshot saved to: \(fileURL.path)")
+            // Index for search
+            ScreenshotIndexer.shared.indexScreenshot(at: fileURL, appName: nil)
             return .success(fileURL)
         } catch {
             logger.error("Failed to write image file: \(error.localizedDescription)")
@@ -340,6 +342,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         do {
             try FileManager.default.trashItem(at: fileURL, resultingItemURL: nil)
             logger.info("Screenshot moved to trash: \(fileURL.path)")
+            ScreenshotIndexer.shared.removeFromIndex(at: fileURL)
         } catch {
             logger.error("Failed to move screenshot to trash: \(error.localizedDescription)")
         }


### PR DESCRIPTION
## Summary
- **Auto-Redact**: New annotation tool that uses on-device Vision OCR to detect sensitive data (emails, API keys, phone numbers, credit cards, IPs, SSNs) and automatically adds blur annotations over them
- **Screenshot Search**: Core Spotlight indexing of screenshots with OCR-extracted text, enabling system-wide search of screenshot content
- All processing is fully on-device using Apple Vision framework - no external API calls
- New `SensitiveDataDetector` class with regex pattern matching on OCR results
- New `ScreenshotIndexer` singleton for Core Spotlight integration
- Auto-Redact tool added to annotation toolbar (eye.slash icon)
- Screenshots are indexed on save and removed from index on trash

## Test plan
- [ ] Open annotation editor, select Auto-Redact tool
- [ ] Capture screenshot containing an email address, verify it gets blurred
- [ ] Test with API keys, phone numbers, credit card numbers
- [ ] Verify blur annotations can be individually removed after auto-redact
- [ ] Save a screenshot, verify it appears in Spotlight search by text content
- [ ] Trash a screenshot, verify it's removed from Spotlight index
- [ ] Verify no network calls are made (all on-device)

Closes #2

https://claude.ai/code/session_01EUZV2oHcXJBoZ6aQRWzy9R