### PR TITLE
Add CLI tool for screenshot automation

### DIFF
--- a/CLI/Sources/CaptureCommand.swift
+++ b/CLI/Sources/CaptureCommand.swift
@@ -1,0 +1,136 @@
+import ArgumentParser
+import AppKit
+import Foundation
+
+struct Capture: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        abstract: "Capture a screenshot"
+    )
+
+    @Flag(name: [.short, .customLong("fullscreen")], help: "Capture entire screen")
+    var fullscreen = false
+
+    @Option(name: [.short, .customLong("output")], help: "Output file path")
+    var output: String?
+
+    @Option(name: .customLong("format"), help: "Output format (png, jpg)")
+    var format: String = "png"
+
+    @Option(name: .customLong("quality"), help: "JPEG quality (1-100)")
+    var quality: Int = 90
+
+    @Flag(name: [.short, .customLong("clipboard")], help: "Copy to clipboard instead of saving")
+    var clipboard = false
+
+    @Option(name: [.customLong("delay")], help: "Delay in seconds before capture")
+    var delay: Double = 0
+
+    mutating func run() throws {
+        // Run the async capture on the main run loop
+        let semaphore = DispatchSemaphore(value: 0)
+        var captureError: Error?
+
+        Task {
+            do {
+                try await performCapture()
+            } catch {
+                captureError = error
+            }
+            semaphore.signal()
+        }
+
+        // Run the run loop while waiting (needed for ScreenCaptureKit)
+        while semaphore.wait(timeout: .now()) == .timedOut {
+            RunLoop.current.run(mode: .default, before: Date(timeIntervalSinceNow: 0.1))
+        }
+
+        if let error = captureError {
+            throw error
+        }
+    }
+
+    private func performCapture() async throws {
+        if delay > 0 {
+            fputs("Capturing in \(Int(delay)) seconds...\n", stderr)
+            try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+        }
+
+        // Use CGWindowListCreateImage for CLI (doesn't require ScreenCaptureKit entitlements)
+        guard let image = CGWindowListCreateImage(
+            CGRect.null,
+            .optionOnScreenOnly,
+            kCGNullWindowID,
+            [.bestResolution, .boundsIgnoreFraming]
+        ) else {
+            throw CLIError.captureFailed("Failed to capture screen")
+        }
+
+        let nsImage = NSImage(cgImage: image, size: NSSize(width: image.width, height: image.height))
+
+        if clipboard {
+            copyToClipboard(nsImage)
+            fputs("Screenshot copied to clipboard\n", stderr)
+            return
+        }
+
+        // Determine output path
+        let outputURL: URL
+        if let output = output {
+            outputURL = URL(fileURLWithPath: output)
+        } else {
+            let formatter = DateFormatter()
+            formatter.dateFormat = "yyyy-MM-dd-HHmmss"
+            let timestamp = formatter.string(from: Date())
+            let filename = "Shotter-\(timestamp).\(format)"
+            let desktop = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("Desktop")
+            outputURL = desktop.appendingPathComponent(filename)
+        }
+
+        // Save image
+        try saveImage(nsImage, to: outputURL)
+        fputs("\(outputURL.path)\n", stdout)
+    }
+
+    private func saveImage(_ image: NSImage, to url: URL) throws {
+        guard let tiffData = image.tiffRepresentation,
+              let bitmap = NSBitmapImageRep(data: tiffData) else {
+            throw CLIError.captureFailed("Failed to convert image")
+        }
+
+        let data: Data
+        if format == "jpg" || format == "jpeg" {
+            guard let jpegData = bitmap.representation(using: .jpeg, properties: [.compressionFactor: NSNumber(value: Float(quality) / 100.0)]) else {
+                throw CLIError.captureFailed("Failed to encode JPEG")
+            }
+            data = jpegData
+        } else {
+            guard let pngData = bitmap.representation(using: .png, properties: [:]) else {
+                throw CLIError.captureFailed("Failed to encode PNG")
+            }
+            data = pngData
+        }
+
+        // Ensure directory exists
+        let directory = url.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        try data.write(to: url)
+    }
+
+    private func copyToClipboard(_ image: NSImage) {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.writeObjects([image])
+    }
+}
+
+enum CLIError: LocalizedError {
+    case captureFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .captureFailed(let message):
+            return message
+        }
+    }
+}

--- a/CLI/Sources/ListCommand.swift
+++ b/CLI/Sources/ListCommand.swift
@@ -1,0 +1,84 @@
+import ArgumentParser
+import Foundation
+
+struct ListCmd: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "list",
+        abstract: "List recent screenshots"
+    )
+
+    @Option(name: .customLong("limit"), help: "Maximum number of results")
+    var limit: Int = 20
+
+    @Flag(name: .customLong("today"), help: "Show only today's screenshots")
+    var today = false
+
+    @Option(name: .customLong("dir"), help: "Screenshots directory")
+    var directory: String?
+
+    mutating func run() throws {
+        let searchDir: URL
+        if let dir = directory {
+            searchDir = URL(fileURLWithPath: dir)
+        } else {
+            // Default: ~/Pictures/Shotter/
+            let picturesURL = FileManager.default.urls(for: .picturesDirectory, in: .userDomainMask).first
+                ?? FileManager.default.homeDirectoryForCurrentUser
+            searchDir = picturesURL.appendingPathComponent("Shotter")
+        }
+
+        guard FileManager.default.fileExists(atPath: searchDir.path) else {
+            fputs("Directory not found: \(searchDir.path)\n", stderr)
+            throw ExitCode.failure
+        }
+
+        let fileManager = FileManager.default
+        let contents = try fileManager.contentsOfDirectory(
+            at: searchDir,
+            includingPropertiesForKeys: [.contentModificationDateKey, .fileSizeKey],
+            options: [.skipsHiddenFiles]
+        )
+
+        var screenshots = contents.filter { url in
+            let ext = url.pathExtension.lowercased()
+            return ["png", "jpg", "jpeg"].contains(ext)
+        }
+
+        // Sort by modification date (newest first)
+        screenshots.sort { a, b in
+            let dateA = (try? a.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate ?? Date.distantPast
+            let dateB = (try? b.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate ?? Date.distantPast
+            return dateA > dateB
+        }
+
+        // Filter to today if requested
+        if today {
+            let calendar = Calendar.current
+            screenshots = screenshots.filter { url in
+                guard let date = (try? url.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate else {
+                    return false
+                }
+                return calendar.isDateInToday(date)
+            }
+        }
+
+        // Apply limit
+        let results = screenshots.prefix(limit)
+
+        if results.isEmpty {
+            fputs("No screenshots found\n", stderr)
+            return
+        }
+
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+
+        for url in results {
+            let values = try? url.resourceValues(forKeys: [.contentModificationDateKey, .fileSizeKey])
+            let date = values?.contentModificationDate.map { dateFormatter.string(from: $0) } ?? "Unknown"
+            let size = values?.fileSize.map { ByteCountFormatter.string(fromByteCount: Int64($0), countStyle: .file) } ?? "?"
+
+            print("\(date)  \(size.padding(toLength: 10, withPad: " ", startingAt: 0))  \(url.lastPathComponent)")
+        }
+    }
+}

--- a/CLI/Sources/ShotterCLI.swift
+++ b/CLI/Sources/ShotterCLI.swift
@@ -1,0 +1,12 @@
+import ArgumentParser
+import Foundation
+
+@main
+struct ShotterCLI: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "shotter",
+        abstract: "Shotter - Screenshot utility for macOS",
+        version: "1.0.0",
+        subcommands: [Capture.self, ListCmd.self]
+    )
+}

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,8 @@ let package = Package(
         .macOS(.v14)
     ],
     dependencies: [
-        .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.5.0")
+        .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.5.0"),
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0")
     ],
     targets: [
         .executableTarget(
@@ -19,6 +20,13 @@ let package = Package(
             resources: [
                 .process("../Resources")
             ]
+        ),
+        .executableTarget(
+            name: "shotter-cli",
+            dependencies: [
+                .product(name: "ArgumentParser", package: "swift-argument-parser")
+            ],
+            path: "CLI/Sources"
         )
     ]
 )


### PR DESCRIPTION
## Summary
- New `shotter-cli` executable target using Swift Argument Parser
- `shotter capture` command with `--fullscreen`, `--output`, `--format`, `--quality`, `--clipboard`, and `--delay` options
- `shotter list` command to list recent screenshots with `--limit`, `--today`, and `--dir` options
- Uses `CGWindowListCreateImage` for CLI capture (no ScreenCaptureKit entitlements needed)
- Separate SPM target that can be built independently: `swift build --target shotter-cli`
- Output path printed to stdout for easy scripting/piping

## Test plan
- [ ] Build CLI: `swift build --target shotter-cli`
- [ ] Run `shotter capture --fullscreen` and verify screenshot saved to Desktop
- [ ] Run `shotter capture --fullscreen --output /tmp/test.png` and verify custom path
- [ ] Run `shotter capture --fullscreen --clipboard` and verify clipboard
- [ ] Run `shotter capture --fullscreen --format jpg --quality 80` and verify JPEG output
- [ ] Run `shotter capture --delay 3` and verify countdown
- [ ] Run `shotter list` and verify screenshot listing
- [ ] Run `shotter list --today` and verify filtering

Closes #3

https://claude.ai/code/session_01EUZV2oHcXJBoZ6aQRWzy9R