### PR TITLE
Add timestamp and app name overlay for screenshots

### DIFF
--- a/Shotter/Sources/App/ShotterApp.swift
+++ b/Shotter/Sources/App/ShotterApp.swift
@@ -92,50 +92,76 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         DebugLogger.log("Application will terminate")
     }
 
+    /// Returns the name of the currently active (frontmost) application, excluding Shotter itself.
+    private func frontmostAppName() -> String? {
+        let workspace = NSWorkspace.shared
+        guard let app = workspace.frontmostApplication,
+              app.bundleIdentifier != Bundle.main.bundleIdentifier else {
+            return nil
+        }
+        return app.localizedName
+    }
+
     private func captureFullscreen(directCopy: Bool = false) {
+        let appName = frontmostAppName()
         Task {
             guard let result = await captureEngine?.captureFullscreen() else {
                 logger.warning("Failed to capture fullscreen")
                 return
             }
-            handleCapture(result.image, preferredScreen: result.preferredScreen, directCopy: directCopy)
+            handleCapture(result.image, preferredScreen: result.preferredScreen, directCopy: directCopy, sourceAppName: appName)
         }
     }
 
     private func captureArea(directCopy: Bool = false) {
+        let appName = frontmostAppName()
         Task {
             guard let result = await captureEngine?.captureArea() else {
                 // User cancelled or capture failed - not necessarily an error
                 logger.info("Area capture returned nil (user cancelled or failed)")
                 return
             }
-            handleCapture(result.image, preferredScreen: result.preferredScreen, directCopy: directCopy)
+            handleCapture(result.image, preferredScreen: result.preferredScreen, directCopy: directCopy, sourceAppName: appName)
         }
     }
 
     private func captureWindow(directCopy: Bool = false) {
+        let appName = frontmostAppName()
         Task {
             guard let result = await captureEngine?.captureWindowInteractive() else {
                 // User cancelled or capture failed
                 logger.info("Window capture returned nil (user cancelled or failed)")
                 return
             }
-            handleCapture(result.image, preferredScreen: result.preferredScreen, directCopy: directCopy)
+            handleCapture(result.image, preferredScreen: result.preferredScreen, directCopy: directCopy, sourceAppName: appName)
         }
     }
-    
+
     private func captureDisplay(_ display: CaptureDisplay) {
+        let appName = frontmostAppName()
         Task {
             guard let result = await captureEngine?.captureDisplay(display) else {
                 logger.warning("Failed to capture display: \(display.name)")
                 return
             }
-            handleCapture(result.image, preferredScreen: result.preferredScreen)
+            handleCapture(result.image, preferredScreen: result.preferredScreen, sourceAppName: appName)
         }
     }
     
-    private func handleCapture(_ image: NSImage, preferredScreen: NSScreen? = nil, directCopy: Bool = false) {
+    private func handleCapture(_ image: NSImage, preferredScreen: NSScreen? = nil, directCopy: Bool = false, sourceAppName: String? = nil) {
         let prefs = PreferencesManager.shared
+
+        // Apply timestamp overlay if enabled
+        let finalImage: NSImage
+        if prefs.timestampOverlayEnabled {
+            finalImage = TimestampOverlay.apply(
+                to: image,
+                appName: sourceAppName,
+                position: prefs.timestampOverlayPosition
+            )
+        } else {
+            finalImage = image
+        }
 
         // Direct-copy mode: Option held + auto-copy is OFF → copy and skip overlay
         let shouldDirectCopy = directCopy && !prefs.autoCopyToClipboard
@@ -149,7 +175,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let result: Result<URL, SaveError>?
         let savedURL: URL?
         if prefs.autoSaveScreenshots {
-            result = saveImage(image)
+            result = saveImage(finalImage)
             savedURL = try? result?.get()
         } else {
             result = nil
@@ -160,7 +186,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Now includes file URL for terminal compatibility (Ghostty, etc.)
         if prefs.autoCopyToClipboard || shouldDirectCopy {
             DispatchQueue.main.async {
-                self.copyToClipboard(image, fileURL: savedURL)
+                self.copyToClipboard(finalImage, fileURL: savedURL)
             }
         }
 
@@ -174,7 +200,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         DispatchQueue.main.async {
             // When auto-save is disabled (no result), show overlay with save functionality
             if result == nil {
-                self.showOverlayWithManualSave(image: image, preferredScreen: preferredScreen)
+                self.showOverlayWithManualSave(image: finalImage, preferredScreen: preferredScreen)
                 return
             }
 
@@ -182,11 +208,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             switch result! {
             case .success(let savedURL):
                 self.overlayController?.showOverlay(
-                    image: image,
+                    image: finalImage,
                     savedURL: savedURL,
                     preferredScreen: preferredScreen,
                     onCopy: {
-                        self.copyToClipboard(image, fileURL: savedURL)
+                        self.copyToClipboard(finalImage, fileURL: savedURL)
                     },
                     onSave: {
                         NSWorkspace.shared.activateFileViewerSelecting([savedURL])
@@ -194,7 +220,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                     onAnnotate: {
                         DebugLogger.log("Overlay annotate clicked (savedURL available)")
                         self.overlayController?.dismissOverlay()
-                        self.openAnnotationEditor(image: image, savedURL: savedURL, preferredScreen: preferredScreen)
+                        self.openAnnotationEditor(image: finalImage, savedURL: savedURL, preferredScreen: preferredScreen)
                     },
                     onDelete: {
                         self.moveToTrash(savedURL)
@@ -203,7 +229,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             case .failure(let error):
                 self.showSaveErrorAlert(error: error)
                 // Auto-save failed - show overlay with manual save option to retry
-                self.showOverlayWithManualSave(image: image, preferredScreen: preferredScreen)
+                self.showOverlayWithManualSave(image: finalImage, preferredScreen: preferredScreen)
             }
         }
     }

--- a/Shotter/Sources/Preferences/PreferencesManager.swift
+++ b/Shotter/Sources/Preferences/PreferencesManager.swift
@@ -96,6 +96,8 @@ class PreferencesManager: ObservableObject {
         static let shortcutArea = "shortcutArea"
         static let shortcutWindow = "shortcutWindow"
         static let overlayPosition = "overlayPosition"
+        static let timestampOverlayEnabled = "timestampOverlayEnabled"
+        static let timestampOverlayPosition = "timestampOverlayPosition"
     }
     
     @Published var saveLocation: URL {
@@ -167,6 +169,20 @@ class PreferencesManager: ObservableObject {
         }
     }
 
+    /// When enabled, screenshots are stamped with a timestamp and active app name.
+    @Published var timestampOverlayEnabled: Bool {
+        didSet {
+            defaults.set(timestampOverlayEnabled, forKey: Keys.timestampOverlayEnabled)
+        }
+    }
+
+    /// Corner position for the timestamp overlay badge.
+    @Published var timestampOverlayPosition: TimestampOverlayPosition {
+        didSet {
+            defaults.set(timestampOverlayPosition.rawValue, forKey: Keys.timestampOverlayPosition)
+        }
+    }
+
     private func saveShortcut(_ config: ShortcutConfig, forKey key: String) {
         if let data = try? JSONEncoder().encode(config) {
             defaults.set(data, forKey: key)
@@ -235,6 +251,16 @@ class PreferencesManager: ObservableObject {
             overlayPosition = position
         } else {
             overlayPosition = .bottomLeft
+        }
+
+        // Load timestamp overlay preference (default to off)
+        timestampOverlayEnabled = defaults.bool(forKey: Keys.timestampOverlayEnabled)
+
+        if let tsPositionString = defaults.string(forKey: Keys.timestampOverlayPosition),
+           let tsPosition = TimestampOverlayPosition(rawValue: tsPositionString) {
+            timestampOverlayPosition = tsPosition
+        } else {
+            timestampOverlayPosition = .bottomLeft
         }
 
         defaults.set(actualLaunchAtLogin, forKey: Keys.launchAtLogin)

--- a/Shotter/Sources/Preferences/PreferencesView.swift
+++ b/Shotter/Sources/Preferences/PreferencesView.swift
@@ -65,6 +65,25 @@ struct PreferencesView: View {
             } header: {
                 Text("General")
             }
+
+            Section {
+                Toggle("Stamp screenshots with timestamp & app name", isOn: $prefs.timestampOverlayEnabled)
+
+                if prefs.timestampOverlayEnabled {
+                    HStack {
+                        Text("Badge position:")
+                        Spacer()
+                        Picker("", selection: $prefs.timestampOverlayPosition) {
+                            ForEach(TimestampOverlayPosition.allCases, id: \.self) { position in
+                                Text(position.displayName).tag(position)
+                            }
+                        }
+                        .frame(width: 130)
+                    }
+                }
+            } header: {
+                Text("Timestamp Overlay")
+            }
             
             Section {
                 ShortcutRow(

--- a/Shotter/Sources/Utils/TimestampOverlay.swift
+++ b/Shotter/Sources/Utils/TimestampOverlay.swift
@@ -1,0 +1,112 @@
+import AppKit
+
+/// Position for the timestamp overlay badge
+enum TimestampOverlayPosition: String, CaseIterable {
+    case topLeft = "topLeft"
+    case topRight = "topRight"
+    case bottomLeft = "bottomLeft"
+    case bottomRight = "bottomRight"
+
+    var displayName: String {
+        switch self {
+        case .topLeft: return "Top Left"
+        case .topRight: return "Top Right"
+        case .bottomLeft: return "Bottom Left"
+        case .bottomRight: return "Bottom Right"
+        }
+    }
+}
+
+/// Renders a timestamp and optional app name overlay onto a screenshot
+struct TimestampOverlay {
+    /// Apply a timestamp (and optional app name) badge to the given image.
+    /// Returns a new image with the overlay composited.
+    static func apply(
+        to image: NSImage,
+        appName: String?,
+        position: TimestampOverlayPosition
+    ) -> NSImage {
+        let size = image.size
+        guard size.width > 0, size.height > 0 else { return image }
+
+        let result = NSImage(size: size)
+        result.lockFocus()
+
+        guard let context = NSGraphicsContext.current?.cgContext else {
+            result.unlockFocus()
+            return image
+        }
+
+        // Draw original image
+        image.draw(in: CGRect(origin: .zero, size: size))
+
+        // Build label text
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        var label = formatter.string(from: Date())
+        if let app = appName, !app.isEmpty {
+            label += "  \(app)"
+        }
+
+        // Determine font size relative to image dimensions (auto-scale)
+        let referenceDimension = min(size.width, size.height)
+        let fontSize = max(min(referenceDimension * 0.018, 18), 10)
+
+        let font = NSFont.systemFont(ofSize: fontSize, weight: .medium)
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.alignment = .left
+
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: font,
+            .foregroundColor: NSColor.white,
+            .paragraphStyle: paragraphStyle
+        ]
+
+        let attributedString = NSAttributedString(string: label, attributes: attributes)
+        let textSize = attributedString.size()
+
+        let paddingH: CGFloat = fontSize * 0.6
+        let paddingV: CGFloat = fontSize * 0.35
+        let badgeWidth = textSize.width + paddingH * 2
+        let badgeHeight = textSize.height + paddingV * 2
+        let margin: CGFloat = fontSize * 0.5
+        let cornerRadius: CGFloat = fontSize * 0.3
+
+        // Calculate badge origin based on position
+        let badgeOrigin: CGPoint
+        switch position {
+        case .topLeft:
+            badgeOrigin = CGPoint(x: margin, y: size.height - badgeHeight - margin)
+        case .topRight:
+            badgeOrigin = CGPoint(x: size.width - badgeWidth - margin, y: size.height - badgeHeight - margin)
+        case .bottomLeft:
+            badgeOrigin = CGPoint(x: margin, y: margin)
+        case .bottomRight:
+            badgeOrigin = CGPoint(x: size.width - badgeWidth - margin, y: margin)
+        }
+
+        let badgeRect = CGRect(origin: badgeOrigin, size: CGSize(width: badgeWidth, height: badgeHeight))
+
+        // Draw semi-transparent background
+        let bgPath = CGPath(roundedRect: badgeRect, cornerWidth: cornerRadius, cornerHeight: cornerRadius, transform: nil)
+        context.setFillColor(NSColor.black.withAlphaComponent(0.55).cgColor)
+        context.addPath(bgPath)
+        context.fillPath()
+
+        // Draw text
+        let textRect = CGRect(
+            x: badgeRect.origin.x + paddingH,
+            y: badgeRect.origin.y + paddingV,
+            width: textSize.width,
+            height: textSize.height
+        )
+
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = NSGraphicsContext(cgContext: context, flipped: false)
+        attributedString.draw(in: textRect)
+        NSGraphicsContext.restoreGraphicsState()
+
+        result.unlockFocus()
+        return result
+    }
+}


### PR DESCRIPTION
## Summary
- Adds an optional overlay that stamps each screenshot with the capture timestamp and active application name
- New toggle in Preferences ("Stamp screenshots with timestamp & app name") with configurable badge position (any corner)
- Semi-transparent rounded badge with auto-scaling font size based on screenshot dimensions
- Detects the frontmost app at capture time (excluding Shotter itself)

## Implementation
- **New file:** `Utils/TimestampOverlay.swift` — renders the badge onto an `NSImage` using Core Graphics
- **PreferencesManager** — two new settings: `timestampOverlayEnabled` (Bool) and `timestampOverlayPosition` (enum)
- **PreferencesView** — new "Timestamp Overlay" section with toggle and position picker
- **ShotterApp** — `handleCapture` applies the overlay before saving/copying; capture methods pass `sourceAppName`

## Test plan
- [ ] Enable "Stamp screenshots with timestamp & app name" in Preferences
- [ ] Capture a fullscreen, area, and window screenshot — verify badge appears in the selected corner
- [ ] Verify badge shows correct date/time and the name of the active app
- [ ] Change badge position to each corner and verify placement
- [ ] Disable the toggle and verify screenshots have no badge
- [ ] Verify the annotation editor receives the stamped image

Closes #27

https://claude.ai/code/session_01HhmCMFixsRrXYmj8hQMYNH