### PR TITLE
Add zoom controls to annotation editor

### DIFF
--- a/Shotter/Sources/Annotations/AnnotationCanvasView.swift
+++ b/Shotter/Sources/Annotations/AnnotationCanvasView.swift
@@ -38,9 +38,14 @@ class AnnotationCanvasView: NSView {
     // Cached CIContext for blur operations (expensive to create)
     private let ciContext = CIContext()
 
-    // Scale and offset for zooming/panning (future feature)
+    // Scale and offset for zooming/panning
     var scale: CGFloat = 1.0
     var offset: CGPoint = .zero
+
+    // Pan tracking
+    private var isPanning = false
+    private var panStartPoint: NSPoint = .zero
+    private var panStartOffset: CGPoint = .zero
     
     override var acceptsFirstResponder: Bool { true }
     override var isFlipped: Bool { false }  // Use standard macOS coordinates
@@ -161,9 +166,22 @@ class AnnotationCanvasView: NSView {
     private func imageRectInView() -> CGRect {
         guard let state = state else { return .zero }
 
-        let imageRect = annotationImageRect(in: bounds.size, imageSize: state.imageSize)
-        scale = imageRect.width / state.imageSize.width
-        return imageRect
+        // Base fit-to-view rect
+        let fitRect = annotationImageRect(in: bounds.size, imageSize: state.imageSize)
+        let baseScale = fitRect.width / state.imageSize.width
+
+        // Apply zoom level from state
+        let zoomedScale = baseScale * state.zoomLevel
+        scale = zoomedScale
+
+        let zoomedWidth = state.imageSize.width * zoomedScale
+        let zoomedHeight = state.imageSize.height * zoomedScale
+
+        // Center in view, then offset by pan
+        let originX = (bounds.width - zoomedWidth) / 2 + state.panOffset.x
+        let originY = (bounds.height - zoomedHeight) / 2 + state.panOffset.y
+
+        return CGRect(x: originX, y: originY, width: zoomedWidth, height: zoomedHeight)
     }
     
     private func drawCheckerboard(in rect: CGRect, context: CGContext) {
@@ -359,8 +377,39 @@ class AnnotationCanvasView: NSView {
         NSCursor.arrow.set()
     }
     
+    // MARK: - Scroll Wheel (Zoom)
+
+    override func scrollWheel(with event: NSEvent) {
+        guard let state = state else {
+            super.scrollWheel(with: event)
+            return
+        }
+
+        // Pinch-to-zoom (trackpad) or Cmd+scroll
+        if event.modifierFlags.contains(.command) || event.phase != [] || event.momentumPhase != [] {
+            let delta = event.scrollingDeltaY
+            if abs(delta) > 0.1 {
+                let factor: CGFloat = 1.0 + delta * 0.01
+                let newZoom = state.zoomLevel * factor
+                state.setZoom(newZoom)
+                needsDisplay = true
+            }
+            return
+        }
+
+        // Regular scroll: pan when zoomed in
+        if state.zoomLevel > 1.0 + 0.01 {
+            state.panOffset.x += event.scrollingDeltaX
+            state.panOffset.y -= event.scrollingDeltaY
+            needsDisplay = true
+            return
+        }
+
+        super.scrollWheel(with: event)
+    }
+
     // MARK: - Keyboard Events
-    
+
     override func keyDown(with event: NSEvent) {
         guard let state = state else {
             super.keyDown(with: event)

--- a/Shotter/Sources/Annotations/AnnotationEditorState.swift
+++ b/Shotter/Sources/Annotations/AnnotationEditorState.swift
@@ -18,6 +18,39 @@ class AnnotationEditorState: ObservableObject {
     @Published var cropRect: CGRect? = nil
     @Published private(set) var canvasFocusRequestID: Int = 0
 
+    // MARK: - Zoom
+
+    @Published var zoomLevel: CGFloat = 1.0  // 1.0 = fit to view
+    @Published var panOffset: CGPoint = .zero
+
+    static let zoomPresets: [CGFloat] = [0.25, 0.5, 0.75, 1.0, 1.5, 2.0, 3.0, 4.0]
+    static let minZoom: CGFloat = 0.25
+    static let maxZoom: CGFloat = 4.0
+
+    /// Zoom display string for the UI
+    var zoomDisplayString: String {
+        "\(Int(zoomLevel * 100))%"
+    }
+
+    func zoomIn() {
+        let next = Self.zoomPresets.first(where: { $0 > zoomLevel + 0.01 }) ?? Self.maxZoom
+        zoomLevel = min(next, Self.maxZoom)
+    }
+
+    func zoomOut() {
+        let prev = Self.zoomPresets.last(where: { $0 < zoomLevel - 0.01 }) ?? Self.minZoom
+        zoomLevel = max(prev, Self.minZoom)
+    }
+
+    func zoomToFit() {
+        zoomLevel = 1.0
+        panOffset = .zero
+    }
+
+    func setZoom(_ level: CGFloat) {
+        zoomLevel = max(Self.minZoom, min(level, Self.maxZoom))
+    }
+
     // Modifier keys
     var isShiftKeyHeld: Bool = false
     
@@ -431,8 +464,20 @@ extension AnnotationEditorState {
                     selectAnnotation(first.id)
                 }
                 return true
+            case "0":
+                zoomToFit()
+                return true
             default:
                 break
+            }
+
+            // Cmd+ and Cmd- for zoom (check keyCode for = and -)
+            if event.keyCode == 24 { // "=" / "+" key
+                zoomIn()
+                return true
+            } else if event.keyCode == 27 { // "-" key
+                zoomOut()
+                return true
             }
         } else {
             // Tool shortcuts

--- a/Shotter/Sources/Annotations/AnnotationEditorWindow.swift
+++ b/Shotter/Sources/Annotations/AnnotationEditorWindow.swift
@@ -349,7 +349,7 @@ struct AnnotationEditorView: View {
                         if state.editingTextAnnotationId != nil {
                             TextEditorOverlay(
                                 state: state,
-                                imageRect: annotationImageRect(in: geometry.size, imageSize: state.imageSize),
+                                imageRect: zoomedImageRect(in: geometry.size),
                                 scale: calculateScale(for: geometry.size)
                             )
                         }
@@ -359,22 +359,36 @@ struct AnnotationEditorView: View {
                 // Bottom bar with tool options (always visible for consistent layout)
                 Divider()
                 ToolOptionsBar(state: state)
+                ZoomBar(state: state)
                 DragMeBar(state: state)
             }
             .background(Color(NSColor.controlBackgroundColor))
         }
     }
     
+    private func zoomedImageRect(in viewSize: CGSize) -> CGRect {
+        let fitRect = annotationImageRect(in: viewSize, imageSize: state.imageSize)
+        let baseScale = fitRect.width / state.imageSize.width
+        let zoomedScale = baseScale * state.zoomLevel
+        let zoomedWidth = state.imageSize.width * zoomedScale
+        let zoomedHeight = state.imageSize.height * zoomedScale
+        let originX = (viewSize.width - zoomedWidth) / 2 + state.panOffset.x
+        let originY = (viewSize.height - zoomedHeight) / 2 + state.panOffset.y
+        return CGRect(x: originX, y: originY, width: zoomedWidth, height: zoomedHeight)
+    }
+
     private func calculateScale(for viewSize: CGSize) -> CGFloat {
         let imageSize = state.imageSize
         let imageAspect = imageSize.width / imageSize.height
         let viewAspect = viewSize.width / viewSize.height
-        
+
+        let baseScale: CGFloat
         if imageAspect > viewAspect {
-            return viewSize.width / imageSize.width
+            baseScale = viewSize.width / imageSize.width
         } else {
-            return viewSize.height / imageSize.height
+            baseScale = viewSize.height / imageSize.height
         }
+        return baseScale * state.zoomLevel
     }
 }
 
@@ -725,6 +739,63 @@ struct ToolOptionsBar: View {
         case .textHighlight:
             return "Drag to highlight"
         }
+    }
+}
+
+// MARK: - Zoom Bar
+
+struct ZoomBar: View {
+    @ObservedObject var state: AnnotationEditorState
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Spacer()
+
+            Button(action: { state.zoomOut() }) {
+                Image(systemName: "minus.magnifyingglass")
+                    .font(.system(size: 12))
+            }
+            .buttonStyle(.plain)
+            .disabled(state.zoomLevel <= AnnotationEditorState.minZoom + 0.01)
+            .help("Zoom Out (\u{2318}-)")
+
+            Picker("", selection: Binding(
+                get: { closestZoomPreset(state.zoomLevel) },
+                set: { state.setZoom($0) }
+            )) {
+                ForEach(AnnotationEditorState.zoomPresets, id: \.self) { preset in
+                    Text("\(Int(preset * 100))%").tag(preset)
+                }
+            }
+            .pickerStyle(.menu)
+            .frame(width: 80)
+            .help("Zoom Level")
+
+            Button(action: { state.zoomIn() }) {
+                Image(systemName: "plus.magnifyingglass")
+                    .font(.system(size: 12))
+            }
+            .buttonStyle(.plain)
+            .disabled(state.zoomLevel >= AnnotationEditorState.maxZoom - 0.01)
+            .help("Zoom In (\u{2318}+)")
+
+            Button(action: { state.zoomToFit() }) {
+                Image(systemName: "arrow.up.left.and.arrow.down.right")
+                    .font(.system(size: 11))
+            }
+            .buttonStyle(.plain)
+            .help("Fit to View (\u{2318}0)")
+
+            Spacer()
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 4)
+        .frame(height: 28)
+        .background(Color(NSColor.windowBackgroundColor))
+    }
+
+    private func closestZoomPreset(_ value: CGFloat) -> CGFloat {
+        AnnotationEditorState.zoomPresets.min(by: { abs($0 - value) < abs($1 - value) }) ?? 1.0
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds visible zoom controls to the annotation editor bottom bar with preset levels (25%–400%)
- Keyboard shortcuts: `Cmd+` / `Cmd-` to zoom in/out, `Cmd+0` to fit to view
- Scroll wheel with `Cmd` or trackpad pinch-to-zoom support
- Pan/scroll when zoomed in beyond fit-to-view level
- Text editor overlay correctly repositions at all zoom levels

## Implementation
- **AnnotationEditorState** — new `zoomLevel` and `panOffset` published properties with zoom presets and helper methods
- **AnnotationCanvasView** — `imageRectInView()` now applies zoom factor and pan offset; added `scrollWheel` handler for zoom/pan
- **AnnotationEditorWindow** — new `ZoomBar` view with zoom in/out buttons, percentage dropdown, and fit-to-view button; `calculateScale` and text overlay positioning updated for zoom

## Test plan
- [ ] Open annotation editor — verify zoom controls appear in bottom bar
- [ ] Click zoom in/out buttons — verify image scales correctly
- [ ] Select zoom preset from dropdown (e.g., 200%) — verify image zooms
- [ ] Press Cmd+ and Cmd- — verify keyboard zoom works
- [ ] Press Cmd+0 — verify image resets to fit-to-view
- [ ] When zoomed in, scroll — verify panning works
- [ ] When zoomed in, place annotations — verify they land at correct positions
- [ ] When zoomed in, double-click text annotation — verify text editor appears at correct position

Closes #31

https://claude.ai/code/session_01HhmCMFixsRrXYmj8hQMYNH