### PR TITLE
Add AI-powered smart file naming using on-device OCR

### DIFF
--- a/Shotter/Sources/Annotations/AnnotationEditorWindow.swift
+++ b/Shotter/Sources/Annotations/AnnotationEditorWindow.swift
@@ -91,21 +91,34 @@ class AnnotationEditorWindow: NSWindow {
     private func saveImage() {
         DebugLogger.log("Save requested")
         guard let finalImage = state.renderFinalImage() else { return }
-        
+
         if let url = savedURL {
             // Overwrite existing file
             saveToDisk(image: finalImage, url: url)
         } else {
-            // Show save panel
-            let savePanel = NSSavePanel()
-            savePanel.allowedContentTypes = [.png]
-            savePanel.nameFieldStringValue = FileNaming.generateFilename()
-            savePanel.directoryURL = PreferencesManager.shared.saveLocation
-            
-            savePanel.beginSheetModal(for: self) { [weak self] response in
-                if response == .OK, let url = savePanel.url {
-                    self?.saveToDisk(image: finalImage, url: url)
+            // Generate filename (smart or basic) then show save panel
+            if PreferencesManager.shared.smartFileNaming {
+                Task {
+                    let filename = await SmartFileNaming.generateFilename(for: finalImage)
+                    await MainActor.run {
+                        self.showSavePanel(for: finalImage, defaultFilename: filename)
+                    }
                 }
+            } else {
+                showSavePanel(for: finalImage, defaultFilename: FileNaming.generateFilename())
+            }
+        }
+    }
+
+    private func showSavePanel(for image: NSImage, defaultFilename: String) {
+        let savePanel = NSSavePanel()
+        savePanel.allowedContentTypes = [.png]
+        savePanel.nameFieldStringValue = defaultFilename
+        savePanel.directoryURL = PreferencesManager.shared.saveLocation
+
+        savePanel.beginSheetModal(for: self) { [weak self] response in
+            if response == .OK, let url = savePanel.url {
+                self?.saveToDisk(image: image, url: url)
             }
         }
     }

--- a/Shotter/Sources/App/ShotterApp.swift
+++ b/Shotter/Sources/App/ShotterApp.swift
@@ -145,7 +145,51 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             SoundManager.shared.playCaptureSound()
         }
 
-        // Only save immediately if auto-save is enabled
+        // When smart file naming is enabled and auto-save is on, use async path
+        if prefs.autoSaveScreenshots && prefs.smartFileNaming {
+            // Copy immediately (don't wait for OCR)
+            if prefs.autoCopyToClipboard || shouldDirectCopy {
+                copyToClipboard(image, fileURL: nil)
+            }
+            if shouldDirectCopy {
+                logger.info("Direct-copy mode: copied to clipboard, skipping overlay")
+                return
+            }
+
+            Task {
+                let result = await saveImageAsync(image)
+                await MainActor.run {
+                    switch result {
+                    case .success(let savedURL):
+                        self.overlayController?.showOverlay(
+                            image: image,
+                            savedURL: savedURL,
+                            preferredScreen: preferredScreen,
+                            onCopy: {
+                                self.copyToClipboard(image, fileURL: savedURL)
+                            },
+                            onSave: {
+                                NSWorkspace.shared.activateFileViewerSelecting([savedURL])
+                            },
+                            onAnnotate: {
+                                DebugLogger.log("Overlay annotate clicked (savedURL available)")
+                                self.overlayController?.dismissOverlay()
+                                self.openAnnotationEditor(image: image, savedURL: savedURL, preferredScreen: preferredScreen)
+                            },
+                            onDelete: {
+                                self.moveToTrash(savedURL)
+                            }
+                        )
+                    case .failure(let error):
+                        self.showSaveErrorAlert(error: error)
+                        self.showOverlayWithManualSave(image: image, preferredScreen: preferredScreen)
+                    }
+                }
+            }
+            return
+        }
+
+        // Synchronous path (no smart naming or no auto-save)
         let result: Result<URL, SaveError>?
         let savedURL: URL?
         if prefs.autoSaveScreenshots {
@@ -258,9 +302,25 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
     
+    /// Async save that uses smart file naming when enabled.
+    private func saveImageAsync(_ image: NSImage) async -> Result<URL, SaveError> {
+        let prefs = PreferencesManager.shared
+        let filename: String
+        if prefs.smartFileNaming {
+            filename = await SmartFileNaming.generateFilename(for: image)
+        } else {
+            filename = FileNaming.generateFilename()
+        }
+        return saveImageWithFilename(image, filename: filename)
+    }
+
     private func saveImage(_ image: NSImage) -> Result<URL, SaveError> {
-        let saveFolder = PreferencesManager.shared.saveLocation
         let filename = FileNaming.generateFilename()
+        return saveImageWithFilename(image, filename: filename)
+    }
+
+    private func saveImageWithFilename(_ image: NSImage, filename: String) -> Result<URL, SaveError> {
+        let saveFolder = PreferencesManager.shared.saveLocation
         let fileURL = saveFolder.appendingPathComponent(filename)
         
         // Ensure directory exists

--- a/Shotter/Sources/Preferences/PreferencesManager.swift
+++ b/Shotter/Sources/Preferences/PreferencesManager.swift
@@ -96,6 +96,7 @@ class PreferencesManager: ObservableObject {
         static let shortcutArea = "shortcutArea"
         static let shortcutWindow = "shortcutWindow"
         static let overlayPosition = "overlayPosition"
+        static let smartFileNaming = "smartFileNaming"
     }
     
     @Published var saveLocation: URL {
@@ -164,6 +165,13 @@ class PreferencesManager: ObservableObject {
     @Published var overlayPosition: OverlayPosition {
         didSet {
             defaults.set(overlayPosition.rawValue, forKey: Keys.overlayPosition)
+        }
+    }
+
+    /// When enabled, screenshots are named using OCR-derived descriptions instead of just timestamps.
+    @Published var smartFileNaming: Bool {
+        didSet {
+            defaults.set(smartFileNaming, forKey: Keys.smartFileNaming)
         }
     }
 
@@ -236,6 +244,9 @@ class PreferencesManager: ObservableObject {
         } else {
             overlayPosition = .bottomLeft
         }
+
+        // Load smart file naming preference (default to off)
+        smartFileNaming = defaults.bool(forKey: Keys.smartFileNaming)
 
         defaults.set(actualLaunchAtLogin, forKey: Keys.launchAtLogin)
     }

--- a/Shotter/Sources/Preferences/PreferencesView.swift
+++ b/Shotter/Sources/Preferences/PreferencesView.swift
@@ -61,6 +61,13 @@ struct PreferencesView: View {
 
                 Toggle("Save screenshots automatically", isOn: $prefs.autoSaveScreenshots)
 
+                VStack(alignment: .leading, spacing: 4) {
+                    Toggle("Smart file naming (AI)", isOn: $prefs.smartFileNaming)
+                    Text("Uses on-device OCR to generate descriptive filenames")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+
                 Toggle("Launch at login", isOn: $prefs.launchAtLogin)
             } header: {
                 Text("General")

--- a/Shotter/Sources/Utils/SmartFileNaming.swift
+++ b/Shotter/Sources/Utils/SmartFileNaming.swift
@@ -1,0 +1,97 @@
+import AppKit
+import Vision
+
+/// Generates descriptive filenames for screenshots using on-device OCR.
+/// Falls back to timestamp-based naming when no text is detected.
+struct SmartFileNaming {
+    /// Maximum length for the descriptive portion of the filename
+    private static let maxDescriptionLength = 60
+
+    /// Analyze an image and generate a descriptive filename.
+    /// Uses Vision framework OCR to extract text content and derive a short description.
+    static func generateFilename(for image: NSImage, extension ext: String = "png") async -> String {
+        guard let text = await extractText(from: image) else {
+            return FileNaming.generateFilename(extension: ext)
+        }
+
+        let description = buildDescription(from: text)
+        if description.isEmpty {
+            return FileNaming.generateFilename(extension: ext)
+        }
+
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd-HHmmss"
+        let timestamp = formatter.string(from: Date())
+        return "Shotter-\(timestamp)-\(description).\(ext)"
+    }
+
+    /// Extract text from an image using Apple Vision framework.
+    static func extractText(from image: NSImage) async -> String? {
+        guard let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
+            return nil
+        }
+
+        return await withCheckedContinuation { continuation in
+            let request = VNRecognizeTextRequest { request, error in
+                guard error == nil,
+                      let observations = request.results as? [VNRecognizedTextObservation] else {
+                    continuation.resume(returning: nil)
+                    return
+                }
+
+                let texts = observations.compactMap { observation in
+                    observation.topCandidates(1).first?.string
+                }
+
+                let combined = texts.joined(separator: " ")
+                continuation.resume(returning: combined.isEmpty ? nil : combined)
+            }
+
+            request.recognitionLevel = .fast  // Use fast for filename generation
+            request.usesLanguageCorrection = false
+
+            let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
+            do {
+                try handler.perform([request])
+            } catch {
+                continuation.resume(returning: nil)
+            }
+        }
+    }
+
+    /// Build a short filename-safe description from extracted text.
+    private static func buildDescription(from text: String) -> String {
+        // Take the first meaningful chunk of text
+        let words = text
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+
+        guard !words.isEmpty else { return "" }
+
+        // Take first few words that fit within the max length
+        var description = ""
+        for word in words {
+            let candidate = description.isEmpty ? word : "\(description) \(word)"
+            if candidate.count > maxDescriptionLength { break }
+            description = candidate
+        }
+
+        // Sanitize for filesystem: replace unsafe chars, collapse whitespace
+        return sanitizeForFilename(description)
+    }
+
+    /// Remove or replace characters that are unsafe in filenames.
+    private static func sanitizeForFilename(_ input: String) -> String {
+        let unsafe = CharacterSet.alphanumerics.inverted
+        let components = input.unicodeScalars
+            .map { unsafe.contains($0) ? "-" : String($0) }
+            .joined()
+
+        // Collapse multiple hyphens and trim
+        let collapsed = components
+            .replacingOccurrences(of: "-{2,}", with: "-", options: .regularExpression)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+
+        return String(collapsed.prefix(maxDescriptionLength))
+    }
+}


### PR DESCRIPTION
## Summary
- Uses Apple Vision framework (on-device OCR) to generate descriptive filenames from screenshot content
- Example: `Shotter-2026-03-30-143022-GitHub-Pull-Request.png` instead of `Shotter-2026-03-30-143022-567.png`
- Falls back to timestamp-only naming when no text is detected
- New toggle in Preferences: "Smart file naming (AI)"

## Implementation
- **New file:** `Utils/SmartFileNaming.swift` — `VNRecognizeTextRequest` (fast mode) extracts text, builds a sanitized description from the first ~60 characters
- **PreferencesManager** — new `smartFileNaming` Bool setting
- **PreferencesView** — toggle with caption explaining on-device OCR
- **ShotterApp** — async save path when smart naming + auto-save are both enabled; immediate clipboard copy doesn't wait for OCR
- **AnnotationEditorWindow** — save panel uses smart naming for suggested filename

## Test plan
- [ ] Enable "Smart file naming (AI)" in Preferences
- [ ] Capture a screenshot of a page with visible text (e.g., a web page)
- [ ] Verify the saved filename includes a descriptive portion derived from visible text
- [ ] Capture a screenshot of a blank/image-only area — verify fallback to timestamp naming
- [ ] Open annotation editor, save — verify smart filename in save dialog
- [ ] Disable the toggle — verify filenames revert to timestamp-only format
- [ ] Verify OCR runs on-device (no network requests)

Closes #34

https://claude.ai/code/session_01HhmCMFixsRrXYmj8hQMYNH