### PR TITLE
Add auto-redact sensitive data in annotation editor

### DIFF
--- a/Shotter/Sources/Annotations/AnnotationEditorState.swift
+++ b/Shotter/Sources/Annotations/AnnotationEditorState.swift
@@ -335,6 +335,46 @@ class AnnotationEditorState: ObservableObject {
         setTool(.select)
     }
 
+    // MARK: - Auto-Redact
+
+    @Published var detectedSensitiveRegions: [SensitiveTextRegion] = []
+    @Published var isDetectingSensitiveData: Bool = false
+
+    func detectSensitiveData() {
+        isDetectingSensitiveData = true
+        Task {
+            let regions = await SensitiveDataDetector.detect(in: baseImage)
+            await MainActor.run {
+                self.detectedSensitiveRegions = regions
+                self.isDetectingSensitiveData = false
+            }
+        }
+    }
+
+    func applyRedactions() {
+        let selectedRegions = detectedSensitiveRegions.filter(\.isSelected)
+        guard !selectedRegions.isEmpty else {
+            detectedSensitiveRegions = []
+            return
+        }
+
+        saveUndoState()
+
+        for region in selectedRegions {
+            let blurAnnotation = BlurAnnotation(
+                bounds: region.bounds,
+                blurRadius: 20
+            )
+            annotations.append(AnyAnnotation(blurAnnotation))
+        }
+
+        detectedSensitiveRegions = []
+    }
+
+    func dismissRedactionResults() {
+        detectedSensitiveRegions = []
+    }
+
     // MARK: - Rendering
     
     /// Render the final image with all annotations

--- a/Shotter/Sources/Annotations/AnnotationEditorWindow.swift
+++ b/Shotter/Sources/Annotations/AnnotationEditorWindow.swift
@@ -336,15 +336,15 @@ struct AnnotationEditorView: View {
             VStack(spacing: 0) {
                 // Toolbar
                 AnnotationToolbar(state: state, onSave: onSave, onCopy: onCopy, onCancel: onCancel)
-                
+
                 Divider()
-                
+
                 // Canvas
                 GeometryReader { geometry in
                     ZStack {
                         AnnotationCanvasRepresentable(state: state)
                             .frame(maxWidth: .infinity, maxHeight: .infinity)
-                        
+
                         // Text editor overlay
                         if state.editingTextAnnotationId != nil {
                             TextEditorOverlay(
@@ -355,13 +355,32 @@ struct AnnotationEditorView: View {
                         }
                     }
                 }
-                
+
                 // Bottom bar with tool options (always visible for consistent layout)
                 Divider()
                 ToolOptionsBar(state: state)
                 DragMeBar(state: state)
             }
             .background(Color(NSColor.controlBackgroundColor))
+
+            // Auto-redact review panel
+            if !state.detectedSensitiveRegions.isEmpty {
+                RedactionReviewOverlay(state: state)
+            }
+
+            // Loading indicator for sensitive data detection
+            if state.isDetectingSensitiveData {
+                VStack(spacing: 12) {
+                    ProgressView()
+                        .scaleEffect(1.2)
+                    Text("Scanning for sensitive data...")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                .padding(24)
+                .background(.ultraThinMaterial)
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+            }
         }
     }
     
@@ -407,6 +426,14 @@ struct AnnotationToolbar: View {
             
             Spacer()
             
+            // Auto-Redact
+            HoverIconButton(
+                icon: "eye.slash",
+                tooltip: "Auto-Redact Sensitive Data",
+                action: { state.detectSensitiveData() }
+            )
+            .disabled(state.isDetectingSensitiveData)
+
             // Undo/Redo
             HStack(spacing: 4) {
                 HoverIconButton(icon: "arrow.uturn.backward", tooltip: "Undo (⌘Z)", action: { state.undo() })
@@ -760,6 +787,104 @@ struct DragMeBar: View {
             }
             return provider
         }
+    }
+}
+
+// MARK: - Redaction Review Overlay
+
+struct RedactionReviewOverlay: View {
+    @ObservedObject var state: AnnotationEditorState
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Spacer()
+
+            VStack(spacing: 12) {
+                HStack {
+                    Image(systemName: "eye.slash")
+                        .foregroundColor(.orange)
+                    Text("Sensitive Data Detected")
+                        .font(.headline)
+                    Spacer()
+                    Button(action: { state.dismissRedactionResults() }) {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundColor(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                }
+
+                if state.detectedSensitiveRegions.isEmpty {
+                    Text("No sensitive data found.")
+                        .foregroundColor(.secondary)
+                        .font(.caption)
+                } else {
+                    ScrollView {
+                        VStack(spacing: 6) {
+                            ForEach(Array(state.detectedSensitiveRegions.enumerated()), id: \.element.id) { index, region in
+                                HStack(spacing: 8) {
+                                    Toggle("", isOn: Binding(
+                                        get: { state.detectedSensitiveRegions[index].isSelected },
+                                        set: { state.detectedSensitiveRegions[index].isSelected = $0 }
+                                    ))
+                                    .toggleStyle(.checkbox)
+                                    .labelsHidden()
+
+                                    Image(systemName: region.category.icon)
+                                        .foregroundColor(.orange)
+                                        .frame(width: 16)
+
+                                    Text(region.category.rawValue)
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
+                                        .frame(width: 70, alignment: .leading)
+
+                                    Text(maskedText(region.text))
+                                        .font(.system(.caption, design: .monospaced))
+                                        .lineLimit(1)
+                                        .truncationMode(.middle)
+
+                                    Spacer()
+                                }
+                            }
+                        }
+                    }
+                    .frame(maxHeight: 150)
+
+                    HStack {
+                        let selectedCount = state.detectedSensitiveRegions.filter(\.isSelected).count
+                        Text("\(selectedCount) of \(state.detectedSensitiveRegions.count) selected")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+
+                        Spacer()
+
+                        Button("Cancel") {
+                            state.dismissRedactionResults()
+                        }
+
+                        Button("Redact Selected") {
+                            state.applyRedactions()
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .disabled(state.detectedSensitiveRegions.filter(\.isSelected).isEmpty)
+                    }
+                }
+            }
+            .padding(16)
+            .background(.ultraThickMaterial)
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .shadow(radius: 8)
+            .padding(.horizontal, 40)
+            .padding(.bottom, 80)
+        }
+    }
+
+    private func maskedText(_ text: String) -> String {
+        if text.count <= 6 { return String(repeating: "*", count: text.count) }
+        let prefix = String(text.prefix(3))
+        let suffix = String(text.suffix(3))
+        let middle = String(repeating: "*", count: min(text.count - 6, 10))
+        return "\(prefix)\(middle)\(suffix)"
     }
 }
 

--- a/Shotter/Sources/Utils/SensitiveDataDetector.swift
+++ b/Shotter/Sources/Utils/SensitiveDataDetector.swift
@@ -1,0 +1,120 @@
+import AppKit
+import Vision
+
+/// A detected region of sensitive text in an image
+struct SensitiveTextRegion: Identifiable {
+    let id = UUID()
+    let text: String
+    let category: SensitiveCategory
+    let bounds: CGRect  // In image coordinates (origin bottom-left)
+    var isSelected: Bool = true  // Selected for redaction by default
+}
+
+/// Categories of sensitive information
+enum SensitiveCategory: String, CaseIterable {
+    case email = "Email"
+    case apiKey = "API Key"
+    case phone = "Phone"
+    case creditCard = "Credit Card"
+    case ipAddress = "IP Address"
+    case ssn = "SSN"
+
+    var icon: String {
+        switch self {
+        case .email: return "envelope"
+        case .apiKey: return "key"
+        case .phone: return "phone"
+        case .creditCard: return "creditcard"
+        case .ipAddress: return "network"
+        case .ssn: return "person.text.rectangle"
+        }
+    }
+}
+
+/// Detects sensitive information in screenshots using on-device OCR + regex pattern matching
+struct SensitiveDataDetector {
+    /// Regex patterns for each sensitive category
+    private static let patterns: [(SensitiveCategory, NSRegularExpression)] = {
+        let defs: [(SensitiveCategory, String)] = [
+            (.email, #"[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}"#),
+            (.apiKey, #"(sk-[a-zA-Z0-9]{20,}|ghp_[a-zA-Z0-9]{36}|AKIA[0-9A-Z]{16}|sk-proj-[a-zA-Z0-9\-_]{20,})"#),
+            (.phone, #"\+?[0-9]{1,3}[\-.\s]?\(?[0-9]{3}\)?[\-.\s]?[0-9]{3}[\-.\s]?[0-9]{4}"#),
+            (.creditCard, #"[0-9]{4}[\-.\s]?[0-9]{4}[\-.\s]?[0-9]{4}[\-.\s]?[0-9]{4}"#),
+            (.ipAddress, #"[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}"#),
+            (.ssn, #"[0-9]{3}[\-][0-9]{2}[\-][0-9]{4}"#),
+        ]
+        return defs.compactMap { category, pattern in
+            guard let regex = try? NSRegularExpression(pattern: pattern, options: []) else { return nil }
+            return (category, regex)
+        }
+    }()
+
+    /// Scan an image for sensitive data. Returns regions in image coordinates.
+    static func detect(in image: NSImage) async -> [SensitiveTextRegion] {
+        guard let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
+            return []
+        }
+
+        let imageSize = image.size
+
+        return await withCheckedContinuation { continuation in
+            let request = VNRecognizeTextRequest { request, error in
+                guard error == nil,
+                      let observations = request.results as? [VNRecognizedTextObservation] else {
+                    continuation.resume(returning: [])
+                    return
+                }
+
+                var regions: [SensitiveTextRegion] = []
+
+                for observation in observations {
+                    guard let candidate = observation.topCandidates(1).first else { continue }
+                    let text = candidate.string
+
+                    for (category, regex) in patterns {
+                        let range = NSRange(text.startIndex..., in: text)
+                        let matches = regex.matches(in: text, options: [], range: range)
+
+                        for match in matches {
+                            guard let swiftRange = Range(match.range, in: text) else { continue }
+                            let matchedText = String(text[swiftRange])
+
+                            // Get bounding box for the matched substring
+                            if let box = try? candidate.boundingBox(for: swiftRange) {
+                                let normalizedRect = box.boundingBox
+                                // Convert from Vision normalized coords (origin bottom-left, 0-1)
+                                // to image coords
+                                let imageRect = CGRect(
+                                    x: normalizedRect.origin.x * imageSize.width,
+                                    y: normalizedRect.origin.y * imageSize.height,
+                                    width: normalizedRect.width * imageSize.width,
+                                    height: normalizedRect.height * imageSize.height
+                                )
+                                // Add padding
+                                let padded = imageRect.insetBy(dx: -4, dy: -2)
+
+                                regions.append(SensitiveTextRegion(
+                                    text: matchedText,
+                                    category: category,
+                                    bounds: padded
+                                ))
+                            }
+                        }
+                    }
+                }
+
+                continuation.resume(returning: regions)
+            }
+
+            request.recognitionLevel = .accurate
+            request.usesLanguageCorrection = false
+
+            let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
+            do {
+                try handler.perform([request])
+            } catch {
+                continuation.resume(returning: [])
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds automatic detection and redaction of sensitive information in screenshots using on-device OCR
- New "Auto-Redact" button (eye.slash icon) in the annotation editor toolbar
- Detects: emails, API keys (OpenAI/GitHub/AWS), phone numbers, credit cards, IP addresses, SSNs
- Review overlay lets users confirm/deselect individual detections before applying blur

## Implementation
- **New file:** `Utils/SensitiveDataDetector.swift` — Vision framework OCR + regex pattern matching, returns bounding boxes in image coordinates
- **AnnotationEditorState** — new `detectSensitiveData()`, `applyRedactions()`, and `dismissRedactionResults()` methods; tracks detection state
- **AnnotationEditorWindow** — Auto-Redact toolbar button, loading spinner during scan, `RedactionReviewOverlay` with per-item toggles and masked text preview

## Privacy
All processing is fully on-device using Apple Vision framework. No data is sent to any server.

## Test plan
- [ ] Open annotation editor with a screenshot containing an email address — click Auto-Redact
- [ ] Verify the review overlay shows the detected email with category icon and masked text
- [ ] Toggle individual items on/off, click "Redact Selected" — verify blur annotations appear over selected regions
- [ ] Test with API keys (sk-..., ghp_...), phone numbers, credit card numbers, IP addresses
- [ ] Verify "Cancel" dismisses without applying any redactions
- [ ] Verify undo (Cmd+Z) removes the applied blur annotations
- [ ] Capture a screenshot with no sensitive data — verify "No sensitive data found" message

Partially addresses #2

https://claude.ai/code/session_01HhmCMFixsRrXYmj8hQMYNH