### PR TITLE
Wire up scrolling capture for full-page screenshots

### DIFF
--- a/Shotter/Sources/App/ShotterApp.swift
+++ b/Shotter/Sources/App/ShotterApp.swift
@@ -51,6 +51,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             onCaptureFullscreen: { [weak self] in self?.captureFullscreen() },
             onCaptureArea: { [weak self] in self?.captureArea() },
             onCaptureWindow: { [weak self] in self?.captureWindow() },
+            onCaptureScrolling: { [weak self] in self?.captureScrolling() },
             onCaptureDisplay: { [weak self] display in self?.captureDisplay(display) },
             onOpenSaveFolder: { self.openSaveFolder() },
             onOpenPreferences: { self.openPreferences() },
@@ -123,7 +124,17 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             handleCapture(result.image, preferredScreen: result.preferredScreen, directCopy: directCopy)
         }
     }
-    
+
+    private func captureScrolling() {
+        Task {
+            guard let result = await captureEngine?.captureScrollingInteractive() else {
+                logger.info("Scrolling capture returned nil (user cancelled or failed)")
+                return
+            }
+            handleCapture(result.image, preferredScreen: result.preferredScreen)
+        }
+    }
+
     private func captureDisplay(_ display: CaptureDisplay) {
         Task {
             guard let result = await captureEngine?.captureDisplay(display) else {

--- a/Shotter/Sources/Capture/CaptureEngine.swift
+++ b/Shotter/Sources/Capture/CaptureEngine.swift
@@ -444,6 +444,57 @@ class CaptureEngine {
         return await captureWindow(window)
     }
 
+    // MARK: - Scrolling Capture
+
+    /// Show window selector, then perform a scrolling capture of the selected window
+    func captureScrollingInteractive() async -> CaptureResult? {
+        await refreshAvailableContent()
+        let windows = await getAvailableWindows()
+
+        guard let selection = await showWindowSelectorForScrolling(windows: windows) else {
+            return nil
+        }
+
+        let session = ScrollingCaptureSession(
+            selection: selection,
+            captureWindow: { [weak self] window in
+                guard let result = await self?.captureWindow(window) else { return nil }
+                return result.image
+            }
+        )
+
+        guard let image = await session.capture() else {
+            logger.error("Scrolling capture failed")
+            return nil
+        }
+
+        // Determine which screen the window is on
+        let windowCenter = CGPoint(x: selection.window.frame.midX, y: selection.window.frame.midY)
+        let mainScreenHeight = NSScreen.screens.first?.frame.height ?? 0
+        let cocoaCenter = NSPoint(x: windowCenter.x, y: mainScreenHeight - windowCenter.y)
+        let containingScreen = NSScreen.screens.first { $0.frame.contains(cocoaCenter) }
+
+        return CaptureResult(image: image, preferredScreen: containingScreen)
+    }
+
+    @MainActor
+    private func showWindowSelectorForScrolling(windows: [SCWindow]) async -> WindowSelectionResult? {
+        return await withCheckedContinuation { continuation in
+            let selector = WindowSelectorController(windows: windows) { [weak self] window in
+                self?.activeWindowSelector = nil
+                guard let window = window else {
+                    continuation.resume(returning: nil)
+                    return
+                }
+                // Use the center of the window as the click point for scroll targeting
+                let clickPoint = CGPoint(x: window.frame.midX, y: window.frame.midY)
+                continuation.resume(returning: WindowSelectionResult(window: window, clickPoint: clickPoint))
+            }
+            self.activeWindowSelector = selector
+            selector.show()
+        }
+    }
+
     // MARK: - Selectors
 
     @MainActor

--- a/Shotter/Sources/MenuBar/MenuBarController.swift
+++ b/Shotter/Sources/MenuBar/MenuBarController.swift
@@ -7,16 +7,18 @@ class MenuBarController: NSObject {
     private let onCaptureFullscreen: () -> Void
     private let onCaptureArea: () -> Void
     private let onCaptureWindow: () -> Void
+    private let onCaptureScrolling: () -> Void
     private let onCaptureDisplay: (CaptureDisplay) -> Void
     private let onOpenSaveFolder: () -> Void
     private let onOpenPreferences: () -> Void
     private let onQuit: () -> Void
     private let getDisplays: () async -> [CaptureDisplay]
-    
+
     init(
         onCaptureFullscreen: @escaping () -> Void,
         onCaptureArea: @escaping () -> Void,
         onCaptureWindow: @escaping () -> Void,
+        onCaptureScrolling: @escaping () -> Void,
         onCaptureDisplay: @escaping (CaptureDisplay) -> Void,
         onOpenSaveFolder: @escaping () -> Void,
         onOpenPreferences: @escaping () -> Void,
@@ -26,6 +28,7 @@ class MenuBarController: NSObject {
         self.onCaptureFullscreen = onCaptureFullscreen
         self.onCaptureArea = onCaptureArea
         self.onCaptureWindow = onCaptureWindow
+        self.onCaptureScrolling = onCaptureScrolling
         self.onCaptureDisplay = onCaptureDisplay
         self.onOpenSaveFolder = onOpenSaveFolder
         self.onOpenPreferences = onOpenPreferences
@@ -82,7 +85,17 @@ class MenuBarController: NSObject {
         windowItem.keyEquivalent = "5"
         windowItem.target = self
         menu.addItem(windowItem)
-        
+
+        let scrollingItem = NSMenuItem(
+            title: "Scrolling Capture",
+            action: #selector(captureScrollingClicked),
+            keyEquivalent: ""
+        )
+        scrollingItem.keyEquivalentModifierMask = [.command, .shift]
+        scrollingItem.keyEquivalent = "6"
+        scrollingItem.target = self
+        menu.addItem(scrollingItem)
+
         menu.addItem(NSMenuItem.separator())
         
         // Capture Display submenu (populated dynamically)
@@ -160,6 +173,10 @@ class MenuBarController: NSObject {
     
     @objc private func captureWindowClicked() {
         onCaptureWindow()
+    }
+
+    @objc private func captureScrollingClicked() {
+        onCaptureScrolling()
     }
     
     @objc private func captureDisplayClicked(_ sender: NSMenuItem) {


### PR DESCRIPTION
## Summary
- Connects the existing `ScrollingCaptureSession` engine to the UI — it was fully implemented but never wired up
- Adds "Scrolling Capture" menu item with `⌘⇧6` shortcut
- User selects a window, then Shotter auto-scrolls and stitches frames into one tall image

## Implementation
- **CaptureEngine** — new `captureScrollingInteractive()` shows the window selector, creates a `ScrollingCaptureSession`, and returns the stitched result
- **MenuBarController** — new "Scrolling Capture" menu item with `onCaptureScrolling` callback
- **ShotterApp** — new `captureScrolling()` method feeding into the standard `handleCapture` flow

## How it works
The existing `ScrollingCaptureSession` (already in the codebase):
1. Brings the target app to front
2. Captures initial frame
3. Probes scroll locations to detect the scrollable viewport
4. Iteratively scrolls and captures frames (up to 20 frames / 40,000px)
5. Stitches frames using signature-based overlap detection
6. Returns a single tall image

## Test plan
- [ ] Click "Scrolling Capture" from the menu bar (or press ⌘⇧6)
- [ ] Select a window with scrollable content (e.g., a long web page in Safari)
- [ ] Verify the app auto-scrolls and produces a single tall stitched image
- [ ] Verify the result appears in the Quick Access Overlay with all standard actions (copy, save, annotate)
- [ ] Test with a non-scrollable window — verify it falls back to a single window capture
- [ ] Verify the capture can be opened in the annotation editor

Closes #35

https://claude.ai/code/session_01HhmCMFixsRrXYmj8hQMYNH