### PR TITLE
Fix 26 bugs from full code review

### DIFF
--- a/Shotter/Sources/Annotations/AnnotationEditorState.swift
+++ b/Shotter/Sources/Annotations/AnnotationEditorState.swift
@@ -28,9 +28,19 @@ class AnnotationEditorState: ObservableObject {
     ]
     
     // MARK: - Undo/Redo
-    
-    private var undoStack: [[AnyAnnotation]] = []
-    private var redoStack: [[AnyAnnotation]] = []
+
+    /// Full editor snapshot so undo can restore crops, counter numbering,
+    /// and the base image — not just the annotation list.
+    private struct EditorSnapshot {
+        let annotations: [AnyAnnotation]
+        let baseImage: NSImage
+        let imageSize: CGSize
+        let hasBeenCropped: Bool
+        let nextCounterNumber: Int
+    }
+
+    private var undoStack: [EditorSnapshot] = []
+    private var redoStack: [EditorSnapshot] = []
     private let maxUndoLevels = 50
     
     // MARK: - Base Image
@@ -131,6 +141,17 @@ class AnnotationEditorState: ObservableObject {
             selectedAnnotationId = nil
         }
     }
+
+    /// Remove an annotation created by an aborted gesture (too-small drag,
+    /// cancelled/empty text), also dropping the undo checkpoint its creation
+    /// pushed — so undo can't resurrect an invalid annotation.
+    func removeFailedCreation(_ id: AnnotationID) {
+        annotations.removeAll { $0.id == id }
+        if selectedAnnotationId == id {
+            selectedAnnotationId = nil
+        }
+        _ = undoStack.popLast()
+    }
     
     func selectAnnotation(_ id: AnnotationID?) {
         // Deselect previous
@@ -188,9 +209,35 @@ class AnnotationEditorState: ObservableObject {
     }
     
     // MARK: - Undo/Redo
-    
+
+    private func currentSnapshot() -> EditorSnapshot {
+        EditorSnapshot(
+            annotations: annotations,
+            baseImage: baseImage,
+            imageSize: imageSize,
+            hasBeenCropped: hasBeenCropped,
+            nextCounterNumber: nextCounterNumber
+        )
+    }
+
+    private func restore(_ snapshot: EditorSnapshot) {
+        baseImage = snapshot.baseImage
+        imageSize = snapshot.imageSize
+        hasBeenCropped = snapshot.hasBeenCropped
+        nextCounterNumber = snapshot.nextCounterNumber
+        // Clear stale isSelected flags baked into the snapshot so no
+        // annotation keeps a ghost selection border after restore.
+        annotations = snapshot.annotations.map { anyAnnotation in
+            var annotation = anyAnnotation.annotation
+            annotation.isSelected = false
+            return AnyAnnotation(annotation)
+        }
+        selectedAnnotationId = nil
+        cropRect = nil
+    }
+
     private func saveUndoState() {
-        undoStack.append(annotations)
+        undoStack.append(currentSnapshot())
         if undoStack.count > maxUndoLevels {
             undoStack.removeFirst()
         }
@@ -200,31 +247,34 @@ class AnnotationEditorState: ObservableObject {
     func saveUndoCheckpoint() {
         saveUndoState()
     }
-    
+
     var canUndo: Bool { !undoStack.isEmpty }
     var canRedo: Bool { !redoStack.isEmpty }
-    
+
     func undo() {
         guard let previousState = undoStack.popLast() else { return }
-        redoStack.append(annotations)
-        annotations = previousState
-        selectedAnnotationId = nil
+        redoStack.append(currentSnapshot())
+        restore(previousState)
     }
-    
+
     func redo() {
         guard let nextState = redoStack.popLast() else { return }
-        undoStack.append(annotations)
-        annotations = nextState
-        selectedAnnotationId = nil
+        undoStack.append(currentSnapshot())
+        restore(nextState)
     }
     
     // MARK: - Text Editing
     
-    func updateTextAnnotation(id: AnnotationID, text: String) {
+    /// Updates a text annotation's content. Pass `recordUndo: false` for the
+    /// first commit of a newly placed annotation — its creation already pushed
+    /// a checkpoint, so create + initial text is a single undoable action.
+    func updateTextAnnotation(id: AnnotationID, text: String, recordUndo: Bool = true) {
         guard let index = annotations.firstIndex(where: { $0.id == id }),
               var textAnnotation = annotations[index].annotation as? TextAnnotation else { return }
-        
-        saveUndoState()
+
+        if recordUndo {
+            saveUndoState()
+        }
         textAnnotation.text = text
         textAnnotation.updateBoundsForText()
         annotations[index] = AnyAnnotation(textAnnotation)
@@ -318,6 +368,10 @@ class AnnotationEditorState: ObservableObject {
             }
         }
 
+        // Checkpoint the pre-crop state so the crop itself is undoable
+        // (restores the original image, size, and annotation positions).
+        saveUndoState()
+
         // Apply changes
         baseImage = croppedImage
         imageSize = newSize
@@ -325,8 +379,6 @@ class AnnotationEditorState: ObservableObject {
         annotations = updatedAnnotations
         selectedAnnotationId = nil
         cropRect = nil
-        undoStack.removeAll()
-        redoStack.removeAll()
         setTool(.select)
     }
 

--- a/Shotter/Sources/Annotations/AnnotationTool.swift
+++ b/Shotter/Sources/Annotations/AnnotationTool.swift
@@ -236,16 +236,16 @@ class ArrowTool: AnnotationTool {
     
     func mouseUp(at point: CGPoint, state: AnnotationEditorState) {
         guard var annotation = currentAnnotation else { return }
-        
+
         // If start and end are too close, remove the annotation
         let distance = hypot(point.x - annotation.startPoint.x, point.y - annotation.startPoint.y)
         if distance < 5 {
-            state.removeAnnotation(annotation.id)
+            state.removeFailedCreation(annotation.id)
         } else {
             annotation.isSelected = false
             state.updateAnnotation(annotation)
         }
-        
+
         startPoint = nil
         currentAnnotation = nil
     }
@@ -303,12 +303,12 @@ class RectangleTool: AnnotationTool {
         
         // If too small, remove
         if annotation.bounds.width < 5 || annotation.bounds.height < 5 {
-            state.removeAnnotation(annotation.id)
+            state.removeFailedCreation(annotation.id)
         } else {
             annotation.isSelected = false
             state.updateAnnotation(annotation)
         }
-        
+
         startPoint = nil
         currentAnnotation = nil
     }
@@ -365,12 +365,12 @@ class EllipseTool: AnnotationTool {
         guard var annotation = currentAnnotation else { return }
         
         if annotation.bounds.width < 5 || annotation.bounds.height < 5 {
-            state.removeAnnotation(annotation.id)
+            state.removeFailedCreation(annotation.id)
         } else {
             annotation.isSelected = false
             state.updateAnnotation(annotation)
         }
-        
+
         startPoint = nil
         currentAnnotation = nil
     }
@@ -412,12 +412,12 @@ class LineTool: AnnotationTool {
         
         let distance = hypot(point.x - annotation.startPoint.x, point.y - annotation.startPoint.y)
         if distance < 5 {
-            state.removeAnnotation(annotation.id)
+            state.removeFailedCreation(annotation.id)
         } else {
             annotation.isSelected = false
             state.updateAnnotation(annotation)
         }
-        
+
         startPoint = nil
         currentAnnotation = nil
     }
@@ -430,10 +430,11 @@ class TextTool: AnnotationTool {
     var cursor: NSCursor { .iBeam }
     
     func mouseDown(at point: CGPoint, state: AnnotationEditorState) {
-        // Create text annotation at click point
+        // Create text annotation at click point. The placeholder is empty —
+        // never a literal string that could be baked into a saved image.
         var annotation = TextAnnotation(
             position: point,
-            text: "Text",
+            text: "",
             strokeColor: .white,
             fontSize: state.fontSize,
             backgroundColor: state.currentColor
@@ -494,12 +495,12 @@ class BlurTool: AnnotationTool {
         guard var annotation = currentAnnotation else { return }
         
         if annotation.bounds.width < 10 || annotation.bounds.height < 10 {
-            state.removeAnnotation(annotation.id)
+            state.removeFailedCreation(annotation.id)
         } else {
             annotation.isSelected = false
             state.updateAnnotation(annotation)
         }
-        
+
         startPoint = nil
         currentAnnotation = nil
     }
@@ -626,7 +627,7 @@ class TextHighlightTool: AnnotationTool {
         guard let annotation = currentAnnotation else { return }
 
         if brushPath.count < 2 {
-            state.removeAnnotation(annotation.id)
+            state.removeFailedCreation(annotation.id)
         }
 
         brushPath = []

--- a/Shotter/Sources/Annotations/AnnotationTypes.swift
+++ b/Shotter/Sources/Annotations/AnnotationTypes.swift
@@ -403,7 +403,7 @@ struct TextAnnotation: Annotation {
         self.createdAt = Date()
         
         // Calculate initial bounds based on text size
-        let font = NSFont(name: fontName, size: fontSize) ?? NSFont.systemFont(ofSize: fontSize)
+        let font = NSFont.systemFont(ofSize: fontSize, weight: .bold)
         let attributes: [NSAttributedString.Key: Any] = [.font: font]
         let textSize = (text as NSString).size(withAttributes: attributes)
         
@@ -427,7 +427,7 @@ struct TextAnnotation: Annotation {
         }
         
         // Draw text
-        let font = NSFont(name: fontName, size: fontSize) ?? NSFont.systemFont(ofSize: fontSize)
+        let font = NSFont.systemFont(ofSize: fontSize, weight: .bold)
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.alignment = .center
         
@@ -457,7 +457,7 @@ struct TextAnnotation: Annotation {
     }
     
     mutating func updateBoundsForText() {
-        let font = NSFont(name: fontName, size: fontSize) ?? NSFont.systemFont(ofSize: fontSize)
+        let font = NSFont.systemFont(ofSize: fontSize, weight: .bold)
         let attributes: [NSAttributedString.Key: Any] = [.font: font]
         let textSize = (text as NSString).size(withAttributes: attributes)
         

--- a/Shotter/Sources/Annotations/OCRService.swift
+++ b/Shotter/Sources/Annotations/OCRService.swift
@@ -1,0 +1,258 @@
+import AppKit
+import Vision
+
+/// Represents a detected text region with its bounding box and content
+struct OCRTextRegion: Identifiable, Equatable {
+    let id: UUID
+    let text: String
+    let bounds: CGRect
+    let confidence: Float
+
+    init(text: String, bounds: CGRect, confidence: Float) {
+        self.id = UUID()
+        self.text = text
+        self.bounds = bounds
+        self.confidence = confidence
+    }
+}
+
+/// Recognition accuracy level for OCR
+enum OCRRecognitionLevel {
+    case fast
+    case accurate
+
+    var vnRecognitionLevel: VNRequestTextRecognitionLevel {
+        switch self {
+        case .fast: return .fast
+        case .accurate: return .accurate
+        }
+    }
+}
+
+/// Error types for OCR operations
+enum OCRError: Error, LocalizedError {
+    case imageConversionFailed
+    case requestFailed(Error)
+    case noResultsFound
+
+    var errorDescription: String? {
+        switch self {
+        case .imageConversionFailed:
+            return "Failed to convert image for OCR processing"
+        case .requestFailed(let error):
+            return "OCR request failed: \(error.localizedDescription)"
+        case .noResultsFound:
+            return "No text detected in the image"
+        }
+    }
+}
+
+/// Service for performing OCR text detection using Apple's Vision framework
+final class OCRService {
+
+    // MARK: - Singleton
+
+    static let shared = OCRService()
+
+    // MARK: - Private Properties
+
+    /// Cache for OCR results keyed by image hash
+    private var cache: [Int: [OCRTextRegion]] = [:]
+
+    /// Serial queue for thread-safe cache access
+    private let cacheQueue = DispatchQueue(label: "com.shotter.ocrservice.cache")
+
+    // MARK: - Initialization
+
+    private init() {}
+
+    // MARK: - Public Methods
+
+    /// Detect text in an image and return word-level bounding boxes
+    /// - Parameters:
+    ///   - image: The NSImage to process
+    ///   - level: Recognition accuracy level (fast or accurate)
+    ///   - minimumConfidence: Minimum confidence threshold (0.0 to 1.0)
+    /// - Returns: Array of detected text regions with bounds and content
+    func detectText(
+        in image: NSImage,
+        level: OCRRecognitionLevel = .accurate,
+        minimumConfidence: Float = 0.5
+    ) async throws -> [OCRTextRegion] {
+        // Check cache first
+        let imageHash = computeImageHash(image)
+        if let cached = getCachedResult(for: imageHash) {
+            return cached.filter { $0.confidence >= minimumConfidence }
+        }
+
+        // Convert NSImage to CGImage
+        guard let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
+            throw OCRError.imageConversionFailed
+        }
+
+        let imageSize = CGSize(width: cgImage.width, height: cgImage.height)
+
+        // Perform OCR
+        let regions = try await performOCR(on: cgImage, imageSize: imageSize, level: level)
+
+        // Cache the results
+        cacheResult(regions, for: imageHash)
+
+        return regions.filter { $0.confidence >= minimumConfidence }
+    }
+
+    /// Clear the OCR cache
+    func clearCache() {
+        cacheQueue.sync {
+            cache.removeAll()
+        }
+    }
+
+    /// Remove cached result for a specific image
+    func invalidateCache(for image: NSImage) {
+        let hash = computeImageHash(image)
+        cacheQueue.sync {
+            _ = cache.removeValue(forKey: hash)
+        }
+    }
+
+    // MARK: - Private Methods
+
+    private func performOCR(
+        on cgImage: CGImage,
+        imageSize: CGSize,
+        level: OCRRecognitionLevel
+    ) async throws -> [OCRTextRegion] {
+        try await withCheckedThrowingContinuation { continuation in
+            let request = VNRecognizeTextRequest { request, error in
+                if let error = error {
+                    continuation.resume(throwing: OCRError.requestFailed(error))
+                    return
+                }
+
+                guard let observations = request.results as? [VNRecognizedTextObservation] else {
+                    continuation.resume(returning: [])
+                    return
+                }
+
+                var regions: [OCRTextRegion] = []
+
+                for observation in observations {
+                    // Get top candidate for this observation
+                    guard let candidate = observation.topCandidates(1).first else {
+                        continue
+                    }
+
+                    // Get bounding boxes for each word
+                    let words = candidate.string.components(separatedBy: .whitespaces)
+                    var currentIndex = candidate.string.startIndex
+
+                    for word in words where !word.isEmpty {
+                        guard let wordRange = candidate.string.range(
+                            of: word,
+                            range: currentIndex..<candidate.string.endIndex
+                        ) else {
+                            continue
+                        }
+
+                        // Try to get bounding box for this word
+                        if let wordBoundingBox = try? candidate.boundingBox(for: wordRange) {
+                            // Convert normalized coordinates to image coordinates.
+                            // Vision uses bottom-left origin with normalized
+                            // coordinates (0-1) — the same bottom-left (y-up)
+                            // convention as the annotation editor's image
+                            // space, so no Y flip is needed.
+                            let normalizedRect = wordBoundingBox.boundingBox
+                            let imageRect = CGRect(
+                                x: normalizedRect.origin.x * imageSize.width,
+                                y: normalizedRect.origin.y * imageSize.height,
+                                width: normalizedRect.width * imageSize.width,
+                                height: normalizedRect.height * imageSize.height
+                            )
+
+                            regions.append(OCRTextRegion(
+                                text: word,
+                                bounds: imageRect,
+                                confidence: candidate.confidence
+                            ))
+                        }
+
+                        currentIndex = wordRange.upperBound
+                    }
+                }
+
+                continuation.resume(returning: regions)
+            }
+
+            // Configure the request
+            request.recognitionLevel = level.vnRecognitionLevel
+            request.usesLanguageCorrection = true
+            request.recognitionLanguages = ["en-US"]  // Default to English, can be extended
+
+            // Create and perform the request
+            let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
+
+            do {
+                try handler.perform([request])
+            } catch {
+                continuation.resume(throwing: OCRError.requestFailed(error))
+            }
+        }
+    }
+
+    /// Compute a hash for the image to use as cache key
+    private func computeImageHash(_ image: NSImage) -> Int {
+        // Use the image's pointer address combined with size for a simple identity-based hash
+        // This works well when the same NSImage instance is reused
+        var hasher = Hasher()
+        hasher.combine(ObjectIdentifier(image))
+        hasher.combine(image.size.width)
+        hasher.combine(image.size.height)
+        return hasher.finalize()
+    }
+
+    private func getCachedResult(for hash: Int) -> [OCRTextRegion]? {
+        cacheQueue.sync {
+            cache[hash]
+        }
+    }
+
+    private func cacheResult(_ regions: [OCRTextRegion], for hash: Int) {
+        cacheQueue.sync {
+            cache[hash] = regions
+        }
+    }
+}
+
+// MARK: - Convenience Extensions
+
+extension OCRService {
+
+    /// Detect text and return regions that intersect with a given rect
+    /// - Parameters:
+    ///   - image: The NSImage to process
+    ///   - rect: The rect to filter results by
+    ///   - level: Recognition accuracy level
+    /// - Returns: Array of text regions that intersect with the given rect
+    func detectText(
+        in image: NSImage,
+        intersecting rect: CGRect,
+        level: OCRRecognitionLevel = .accurate
+    ) async throws -> [OCRTextRegion] {
+        let allRegions = try await detectText(in: image, level: level)
+        return allRegions.filter { $0.bounds.intersects(rect) }
+    }
+
+    /// Detect text and return the full text content as a string
+    /// - Parameters:
+    ///   - image: The NSImage to process
+    ///   - level: Recognition accuracy level
+    /// - Returns: All detected text concatenated with spaces
+    func extractText(
+        from image: NSImage,
+        level: OCRRecognitionLevel = .accurate
+    ) async throws -> String {
+        let regions = try await detectText(in: image, level: level)
+        return regions.map { $0.text }.joined(separator: " ")
+    }
+}

--- a/Shotter/Sources/Annotations/TextEditorOverlay.swift
+++ b/Shotter/Sources/Annotations/TextEditorOverlay.swift
@@ -60,45 +60,62 @@ struct TextEditorOverlay: View {
                 )
             }
             .onAppear {
-                editText = textAnnotation.text == "Text" ? "" : textAnnotation.text
+                editText = textAnnotation.text
                 isFocused = true
             }
         }
     }
-    
+
     private func convertToViewCoordinates(_ imageBounds: CGRect) -> CGRect {
+        // Annotation bounds are bottom-left origin (y-up, matching the
+        // non-flipped canvas); SwiftUI positions are top-left origin (y-down).
+        // Flip Y so the editor appears exactly where the user clicked.
         CGRect(
             x: imageRect.origin.x + imageBounds.origin.x * scale,
-            y: imageRect.origin.y + imageBounds.origin.y * scale,
+            y: imageRect.maxY - imageBounds.maxY * scale,
             width: imageBounds.width * scale,
             height: imageBounds.height * scale
         )
     }
-    
+
+    /// A freshly placed annotation still has its empty placeholder text.
+    private func isNewAnnotation(_ id: AnnotationID) -> Bool {
+        guard let anyAnnotation = state.annotations.first(where: { $0.id == id }),
+              let textAnnotation = anyAnnotation.annotation as? TextAnnotation else {
+            return false
+        }
+        return textAnnotation.text.isEmpty
+    }
+
     private func finishEditing() {
         guard let editingId = state.editingTextAnnotationId else { return }
-        
+        let isNew = isNewAnnotation(editingId)
+
         if editText.isEmpty {
-            // Remove empty text annotations
-            state.removeAnnotation(editingId)
+            // Remove empty text annotations; for a never-committed placeholder
+            // also drop its creation checkpoint so undo can't resurrect it
+            if isNew {
+                state.removeFailedCreation(editingId)
+            } else {
+                state.removeAnnotation(editingId)
+            }
         } else {
-            state.updateTextAnnotation(id: editingId, text: editText)
+            // Creation already pushed a checkpoint for new annotations, so
+            // create + first text commit undoes as a single action
+            state.updateTextAnnotation(id: editingId, text: editText, recordUndo: !isNew)
         }
-        
+
         state.finishTextEditing()
     }
-    
+
     private func cancelEditing() {
         guard let editingId = state.editingTextAnnotationId else { return }
-        
-        // Check if this is a new annotation (text is "Text")
-        if let anyAnnotation = state.annotations.first(where: { $0.id == editingId }),
-           let textAnnotation = anyAnnotation.annotation as? TextAnnotation,
-           textAnnotation.text == "Text" {
-            // Remove the placeholder
-            state.removeAnnotation(editingId)
+
+        // Remove a never-committed placeholder without leaving an undo entry
+        if isNewAnnotation(editingId) {
+            state.removeFailedCreation(editingId)
         }
-        
+
         state.finishTextEditing()
     }
 }

--- a/Shotter/Sources/App/ShotterApp.swift
+++ b/Shotter/Sources/App/ShotterApp.swift
@@ -185,6 +185,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             // Auto-save was attempted - handle success or failure
             switch result! {
             case .success(let savedURL):
+                // The overlay dismisses itself on annotate/delete/copy actions.
                 self.overlayController?.showOverlay(
                     image: image,
                     savedURL: savedURL,
@@ -197,7 +198,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                     },
                     onAnnotate: {
                         DebugLogger.log("Overlay annotate clicked (savedURL available)")
-                        self.overlayController?.dismissOverlay()
                         self.openAnnotationEditor(image: image, savedURL: savedURL, preferredScreen: preferredScreen)
                     },
                     onDelete: {
@@ -214,7 +214,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     /// Shows overlay with manual save functionality (when auto-save is disabled)
     private func showOverlayWithManualSave(image: NSImage, preferredScreen: NSScreen?) {
-        self.overlayController?.showOverlay(
+        // Captured after showOverlay returns; dismisses only this overlay
+        // (other stacked overlays stay up).
+        var dismissThisOverlay: (() -> Void)?
+
+        let dismiss = self.overlayController?.showOverlay(
             image: image,
             savedURL: nil,
             preferredScreen: preferredScreen,
@@ -222,27 +226,26 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 self.copyToClipboard(image, fileURL: nil)
             },
             onSave: {
-                // Manual save: save the file, then dismiss overlay
+                // Manual save: save the file, then dismiss this overlay
                 let result = self.saveImage(image)
                 switch result {
                 case .success(let url):
                     logger.info("Manual save completed: \(url.path)")
-                    self.overlayController?.dismissOverlay()
+                    dismissThisOverlay?()
                 case .failure(let error):
                     self.showSaveErrorAlert(error: error)
                 }
             },
             onAnnotate: {
                 DebugLogger.log("Overlay annotate clicked (manual save mode)")
-                self.overlayController?.dismissOverlay()
                 self.openAnnotationEditor(image: image, savedURL: nil, preferredScreen: preferredScreen)
             },
             onDelete: {
-                // No file exists - just discard by dismissing overlay
+                // No file exists - the overlay dismisses itself
                 logger.info("Discarding unsaved screenshot")
-                self.overlayController?.dismissOverlay()
             }
         )
+        dismissThisOverlay = dismiss
     }
     
     private enum SaveError: LocalizedError {

--- a/Shotter/Sources/Capture/AreaSelectorWindow.swift
+++ b/Shotter/Sources/Capture/AreaSelectorWindow.swift
@@ -56,6 +56,7 @@ class AreaSelectorWindow {
     private var coordinator: AreaSelectionCoordinator?
     private var hasCompleted = false
     private var localKeyMonitor: Any?
+    private var hasPushedCursor = false
     
     init(screenCaptures: [(screen: NSScreen, image: CGImage)], completion: @escaping (AreaSelectorResult) -> Void) {
         self.completion = completion
@@ -88,10 +89,18 @@ class AreaSelectorWindow {
     
     func show() {
         NSCursor.crosshair.push()
+        hasPushedCursor = true
         installLocalKeyMonitor()
         for window in overlayWindows {
             window.show()
         }
+    }
+
+    deinit {
+        // Safety net: if the selector is deallocated without completing,
+        // still release the key monitor and balance the cursor stack —
+        // otherwise both leak for the app's lifetime.
+        teardown()
     }
 
     func toggleMode() {
@@ -119,13 +128,21 @@ class AreaSelectorWindow {
 
     private func complete(with result: AreaSelectorResult) {
         hasCompleted = true
-        removeLocalKeyMonitor()
-        NSCursor.pop()
+        teardown()
         for window in overlayWindows {
             window.orderOut(nil)
         }
         completion?(result)
         completion = nil
+    }
+
+    /// Single teardown path — idempotent, invoked from both complete() and deinit.
+    private func teardown() {
+        removeLocalKeyMonitor()
+        if hasPushedCursor {
+            NSCursor.pop()
+            hasPushedCursor = false
+        }
     }
 
     private func installLocalKeyMonitor() {
@@ -501,8 +518,10 @@ class AreaSelectionView: NSView {
                 NSGraphicsContext.restoreGraphicsState()
             }
 
-            // Draw border around selection (only on the screen where selection is visible)
-            if selectionRect.intersects(bounds) && bounds.contains(selectionRect) {
+            // Draw border around selection — each screen draws its portion,
+            // clipped naturally to its own bounds, so cross-display selections
+            // keep a visible outline.
+            if selectionRect.intersects(bounds) {
                 NSColor.white.setStroke()
                 let borderPath = NSBezierPath(rect: selectionRect)
                 borderPath.lineWidth = 2
@@ -748,12 +767,17 @@ class AreaSelectionView: NSView {
         dimensionLabel?.stringValue = text
         dimensionLabel?.sizeToFit()
         
-        // Position below selection
+        // Position below selection; flip inside when it would clip at the
+        // screen edge, and clamp horizontally so it stays readable.
         if let label = dimensionLabel {
             var labelFrame = label.frame
             labelFrame.size.width += 12
             labelFrame.origin.x = rect.midX - labelFrame.width / 2
             labelFrame.origin.y = rect.minY - labelFrame.height - 8
+            if labelFrame.origin.y < 4 {
+                labelFrame.origin.y = rect.minY + 8
+            }
+            labelFrame.origin.x = min(max(labelFrame.origin.x, 4), bounds.maxX - labelFrame.width - 4)
             label.frame = labelFrame
         }
     }

--- a/Shotter/Sources/Capture/CaptureEngine.swift
+++ b/Shotter/Sources/Capture/CaptureEngine.swift
@@ -37,6 +37,25 @@ class CaptureEngine {
     private var activeAreaSelector: AreaSelectorWindow?
     private var activeWindowSelector: WindowSelectorController?
 
+    // Guards against re-entrant captures (e.g. pressing the hotkey twice),
+    // which would orphan the active selector and permanently hang its task.
+    // Only read/written on the main actor.
+    private var isCaptureFlowActive = false
+
+    /// Atomically claim the capture flow. Returns false if a capture is already in progress.
+    @MainActor
+    private func beginCaptureFlow() -> Bool {
+        guard !isCaptureFlowActive else { return false }
+        isCaptureFlowActive = true
+        return true
+    }
+
+    private func endCaptureFlow() {
+        Task { @MainActor in
+            self.isCaptureFlowActive = false
+        }
+    }
+
     // Pre-capture cache for preserving menus/tooltips during hotkey capture
     private var preCapturedScreens: [(screen: NSScreen, image: CGImage)]?
     private var preCaptureTimestamp: Date?
@@ -108,6 +127,10 @@ class CaptureEngine {
 
     /// Capture the display at cursor position (default behavior)
     func captureFullscreen() async -> CaptureResult? {
+        guard await MainActor.run(body: { !isCaptureFlowActive }) else {
+            logger.info("Ignoring fullscreen capture - a selector is already active")
+            return nil
+        }
         guard let display = await getDisplayAtCursor() else {
             logger.warning("No display available for fullscreen capture")
             return nil
@@ -130,7 +153,13 @@ class CaptureEngine {
 
     private func captureDisplayCGImage(_ display: CaptureDisplay) async -> CGImage? {
         let scaleFactor = display.scaleFactor
-        let filter = SCContentFilter(display: display.scDisplay, excludingWindows: [])
+        // Exclude Shotter's own windows (post-capture overlay thumbnail, panels)
+        // so they never appear baked into the screenshot.
+        let ownPID = pid_t(ProcessInfo.processInfo.processIdentifier)
+        let ownWindows = availableContent?.windows.filter {
+            $0.owningApplication?.processID == ownPID
+        } ?? []
+        let filter = SCContentFilter(display: display.scDisplay, excludingWindows: ownWindows)
         let config = SCStreamConfiguration()
 
         config.width = Int(CGFloat(display.scDisplay.width) * scaleFactor)
@@ -196,6 +225,12 @@ class CaptureEngine {
     // MARK: - Area Capture
 
     func captureArea() async -> CaptureResult? {
+        guard await beginCaptureFlow() else {
+            logger.info("Ignoring area capture - capture already in progress")
+            return nil
+        }
+        defer { endCaptureFlow() }
+
         let displays = await getAvailableDisplays()
         var screenCaptures: [(screen: NSScreen, image: CGImage)]
 
@@ -438,6 +473,12 @@ class CaptureEngine {
 
     /// Show window picker and capture selected window
     func captureWindowInteractive() async -> CaptureResult? {
+        guard await beginCaptureFlow() else {
+            logger.info("Ignoring window capture - capture already in progress")
+            return nil
+        }
+        defer { endCaptureFlow() }
+
         guard let window = await showWindowSelector() else {
             return nil
         }

--- a/Shotter/Sources/Capture/WindowSelectorController.swift
+++ b/Shotter/Sources/Capture/WindowSelectorController.swift
@@ -233,8 +233,13 @@ class WindowSelectorView: NSView {
         guard localFrame.intersects(bounds) else { return }
         
         // Clear the window area
+        let previousOperation = NSGraphicsContext.current?.compositingOperation
+        NSGraphicsContext.current?.compositingOperation = .clear
         NSColor.clear.setFill()
         localFrame.intersection(bounds).fill()
+        if let previousOperation {
+            NSGraphicsContext.current?.compositingOperation = previousOperation
+        }
         
         // Draw highlight border
         NSColor.systemBlue.setStroke()

--- a/Shotter/Sources/Hotkeys/HotkeyManager.swift
+++ b/Shotter/Sources/Hotkeys/HotkeyManager.swift
@@ -9,6 +9,7 @@ class HotkeyManager {
     private var runLoopSource: CFRunLoopSource?
     private var shortcutObserver: NSObjectProtocol?
     private var activationObserver: NSObjectProtocol?
+    private var permissionRetryTimer: Timer?
     
     private let onFullscreen: (Bool) -> Void  // Bool = directCopy (Option held)
     private let onArea: (Bool) -> Void
@@ -48,6 +49,7 @@ class HotkeyManager {
     
     deinit {
         removeEventTap()
+        stopPermissionRetryTimer()
         if let observer = shortcutObserver {
             NotificationCenter.default.removeObserver(observer)
         }
@@ -90,12 +92,38 @@ class HotkeyManager {
         guard Permissions.checkAccessibility() else {
             removeEventTap()
             logger.info("Accessibility unavailable - hotkey event tap removed")
+            // Keep polling so hotkeys come back as soon as permission is re-granted
+            // (a menu-bar app rarely becomes "active", so the activation observer
+            // alone never fires for grants made in System Settings).
+            startPermissionRetryTimer()
             return
         }
 
         if eventTap == nil {
             setupEventTap()
         }
+    }
+
+    private func startPermissionRetryTimer() {
+        guard permissionRetryTimer == nil else { return }
+        permissionRetryTimer = Timer.scheduledTimer(withTimeInterval: 3.0, repeats: true) { [weak self] timer in
+            guard let self else {
+                timer.invalidate()
+                return
+            }
+            Permissions.invalidateCache()
+            guard Permissions.checkAccessibility() else { return }
+            self.setupEventTap()
+            if self.eventTap != nil {
+                self.stopPermissionRetryTimer()
+                logger.info("Accessibility granted - hotkey event tap registered without relaunch")
+            }
+        }
+    }
+
+    private func stopPermissionRetryTimer() {
+        permissionRetryTimer?.invalidate()
+        permissionRetryTimer = nil
     }
     
     private func setupEventTap() {
@@ -104,6 +132,7 @@ class HotkeyManager {
         // Check accessibility permissions
         guard Permissions.checkAccessibility() else {
             logger.warning("Accessibility permission not granted - hotkeys disabled")
+            startPermissionRetryTimer()
             return
         }
         
@@ -194,7 +223,11 @@ class HotkeyManager {
                 }
                 return nil
             default:
-                break
+                // Swallow capture shortcuts while a selector is up — re-entering
+                // capture would orphan the active selector and hang its task.
+                if matchesAnyCaptureShortcut(keyCode: keyCode, flags: flags) {
+                    return nil
+                }
             }
         }
 
@@ -243,6 +276,12 @@ class HotkeyManager {
         return Unmanaged.passUnretained(event)
     }
     
+    private func matchesAnyCaptureShortcut(keyCode: Int, flags: CGEventFlags) -> Bool {
+        [fullscreenShortcut, areaShortcut, windowShortcut].contains { shortcut in
+            shortcut.isEnabled && matchesShortcut(keyCode: keyCode, flags: flags, shortcut: shortcut, allowExtraOption: true)
+        }
+    }
+
     private func matchesShortcut(keyCode: Int, flags: CGEventFlags, shortcut: ShortcutConfig, allowExtraOption: Bool = false) -> Bool {
         guard keyCode == shortcut.keyCode else { return false }
 

--- a/Shotter/Sources/Overlay/OverlayController.swift
+++ b/Shotter/Sources/Overlay/OverlayController.swift
@@ -4,21 +4,21 @@ import UniformTypeIdentifiers
 
 private enum OverlayLayout {
     static let overlayWidth: CGFloat = 280
-    static let overlayHeight: CGFloat = 180
+    static let minOverlayHeight: CGFloat = 150
+    static let maxOverlayHeight: CGFloat = 280
     static let actionButtonSize: CGFloat = 28
     static let actionButtonSpacing: CGFloat = 8
     static let actionBarInnerPadding: CGFloat = 6
     static let actionBarOuterPadding: CGFloat = 8
+    static let stackSpacing: CGFloat = 12
+    static let screenPadding: CGFloat = 20
 }
 
 private enum DragExportError: LocalizedError {
-    case sourceUnavailable
     case imageConversionFailed
 
     var errorDescription: String? {
         switch self {
-        case .sourceUnavailable:
-            return "The screenshot was no longer available for dragging."
         case .imageConversionFailed:
             return "Could not convert the screenshot to PNG for dragging."
         }
@@ -26,9 +26,13 @@ private enum DragExportError: LocalizedError {
 }
 
 class OverlayController {
-    private var overlayWindow: OverlayWindow?
-    private var dismissTimer: Timer?
-    
+    private var overlayWindows: [OverlayWindow] = []
+    private let maxStackedOverlays = 5
+
+    /// Shows a post-capture overlay. New captures stack above existing overlays
+    /// instead of replacing them. Returns a closure that dismisses this
+    /// specific overlay (used e.g. after a successful manual save).
+    @discardableResult
     func showOverlay(
         image: NSImage,
         savedURL: URL?,
@@ -37,96 +41,184 @@ class OverlayController {
         onSave: @escaping () -> Void,
         onAnnotate: @escaping () -> Void,
         onDelete: @escaping () -> Void
-    ) {
-        // Dismiss existing overlay
-        dismissOverlay()
+    ) -> () -> Void {
+        // Cap the stack; drop the oldest overlay when full
+        if overlayWindows.count >= maxStackedOverlays, let oldest = overlayWindows.first {
+            dismiss(oldest)
+        }
 
-        // Create overlay window
-        overlayWindow = OverlayWindow(
+        let window = OverlayWindow(
             image: image,
             savedURL: savedURL,
             preferredScreen: preferredScreen,
-            onCopy: { [weak self] in
-                onCopy()
-                self?.dismissOverlay()
-            },
+            onCopy: onCopy,
             onSave: onSave,
             onAnnotate: onAnnotate,
-            onDelete: { [weak self] in
-                onDelete()
-                self?.dismissOverlay()
-            },
-            onPauseDismiss: { [weak self] in
-                self?.pauseDismissTimer()
-            },
-            onResumeDismiss: { [weak self] in
-                self?.resumeDismissTimer()
-            },
-            onDragSuccess: { [weak self] in
-                self?.dismissOverlay()
-            },
-            onDismiss: { [weak self] in
-                self?.dismissOverlay()
-            }
+            onDelete: onDelete
         )
-        
-        overlayWindow?.show()
-        
-        // Start auto-dismiss timer
-        startDismissTimer()
-    }
-    
-    private func startDismissTimer() {
-        dismissTimer?.invalidate()
-        let delay = PreferencesManager.shared.overlayAutoDismissDelay
-
-        // Don't create timer if delay is negative (never auto-dismiss)
-        guard delay > 0 else {
-            return
+        window.onRequestDismiss = { [weak self, weak window] in
+            guard let self, let window else { return }
+            self.dismiss(window)
         }
 
-        dismissTimer = Timer.scheduledTimer(withTimeInterval: delay, repeats: false) { [weak self] _ in
-            self?.dismissOverlay()
+        overlayWindows.append(window)
+        restack(animated: false)
+        window.show()
+        window.startAutoDismissTimer()
+
+        return { [weak self, weak window] in
+            guard let self, let window else { return }
+            self.dismiss(window)
         }
     }
-    
-    func pauseDismissTimer() {
-        dismissTimer?.invalidate()
+
+    /// Dismiss one overlay and slide the remaining stack back into place.
+    func dismiss(_ window: OverlayWindow) {
+        if let index = overlayWindows.firstIndex(where: { $0 === window }) {
+            overlayWindows.remove(at: index)
+        }
+        window.close()
+        restack(animated: true)
     }
-    
-    func resumeDismissTimer() {
-        startDismissTimer()
-    }
-    
+
+    /// Dismiss every overlay (kept for callers that need a full reset).
     func dismissOverlay() {
-        dismissTimer?.invalidate()
-        dismissTimer = nil
-        overlayWindow?.close()
-        overlayWindow = nil
+        let windows = overlayWindows
+        overlayWindows.removeAll()
+        for window in windows {
+            window.close()
+        }
     }
-    
-    private func flashSuccess() {
-        // Brief visual feedback that copy succeeded
-        overlayWindow?.flashCopySuccess()
+
+    /// Lay out overlays bottom-up per screen: the newest capture sits at the
+    /// base position, older ones are pushed upward.
+    private func restack(animated: Bool) {
+        var nextYByScreen: [String: CGFloat] = [:]
+
+        for window in overlayWindows.reversed() {
+            guard let screen = window.anchorScreen ?? NSScreen.main else { continue }
+            let key = "\(screen.frame.origin)"
+            let baseY = screen.visibleFrame.minY + OverlayLayout.screenPadding
+            let y = nextYByScreen[key] ?? baseY
+
+            var frame = window.frame
+            frame.origin.y = y
+            if animated {
+                NSAnimationContext.runAnimationGroup { context in
+                    context.duration = 0.2
+                    window.animator().setFrame(frame, display: true)
+                }
+            } else {
+                window.setFrame(frame, display: true)
+            }
+
+            nextYByScreen[key] = y + frame.height + OverlayLayout.stackSpacing
+        }
     }
 }
 
-class OverlayWindow: NSPanel, NSDraggingSource, NSFilePromiseProviderDelegate {
+/// Owns the promised screenshot data for a drag session, independent of the
+/// overlay window's lifetime — so slow drop targets (Mail, network folders)
+/// still receive the file after the overlay is dismissed and deallocated.
+final class ScreenshotDragSource: NSObject, NSFilePromiseProviderDelegate {
+    private static var activeSources: [ObjectIdentifier: ScreenshotDragSource] = [:]
+
+    private let image: NSImage
+    private let savedURL: URL?
+    private let filename: String
+
+    init(image: NSImage, savedURL: URL?, filename: String) {
+        self.image = image
+        self.savedURL = savedURL
+        self.filename = filename
+    }
+
+    func retainUntilFulfilled() {
+        Self.activeSources[ObjectIdentifier(self)] = self
+    }
+
+    func release() {
+        Self.activeSources[ObjectIdentifier(self)] = nil
+    }
+
+    // MARK: - NSFilePromiseProviderDelegate
+
+    func filePromiseProvider(_ filePromiseProvider: NSFilePromiseProvider, fileNameForType fileType: String) -> String {
+        filename
+    }
+
+    func filePromiseProvider(
+        _ filePromiseProvider: NSFilePromiseProvider,
+        writePromiseTo url: URL,
+        completionHandler: @escaping (Error?) -> Void
+    ) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            defer {
+                DispatchQueue.main.async { self.release() }
+            }
+            do {
+                try self.write(to: url)
+                completionHandler(nil)
+            } catch {
+                completionHandler(error)
+            }
+        }
+    }
+
+    private func write(to destinationURL: URL) throws {
+        let fileManager = FileManager.default
+
+        if let savedURL = savedURL, fileManager.fileExists(atPath: savedURL.path) {
+            if fileManager.fileExists(atPath: destinationURL.path) {
+                try fileManager.removeItem(at: destinationURL)
+            }
+            try fileManager.copyItem(at: savedURL, to: destinationURL)
+            return
+        }
+
+        // Fall back to converting image to PNG
+        guard let tiffData = image.tiffRepresentation,
+              let bitmap = NSBitmapImageRep(data: tiffData),
+              let pngData = bitmap.representation(using: .png, properties: [:]) else {
+            throw DragExportError.imageConversionFailed
+        }
+        try pngData.write(to: destinationURL, options: .atomic)
+    }
+}
+
+class OverlayWindow: NSPanel, NSDraggingSource {
     private var hostingView: NSHostingView<OverlayView>?
+
+    /// Screen this overlay is anchored to, used for stack layout.
+    let anchorScreen: NSScreen?
+
+    var onRequestDismiss: (() -> Void)?
 
     // Drag state
     private var image: NSImage
     private var savedURL: URL?
-    private var onPauseDismiss: () -> Void
-    private var onResumeDismiss: () -> Void
-    private var onDragSuccess: () -> Void
     private var isDragging = false
     private var mouseDownLocation: NSPoint?
-    private var currentPromiseFilename: String?
+    private var currentDragSource: ScreenshotDragSource?
+
+    // Auto-dismiss timer, scoped to this window so overlapping overlays
+    // never interfere with each other's timing.
+    private var dismissTimer: Timer?
 
     // Button exclusion zones (top-right action bar, top-left close button)
     private let actionBarRect: NSRect
     private let closeButtonRect: NSRect
+
+    /// Window height derived from the capture's aspect ratio, so the
+    /// thumbnail shows the whole capture instead of a center crop.
+    static func overlayHeight(for image: NSImage) -> CGFloat {
+        guard image.size.width > 0, image.size.height > 0 else {
+            return OverlayLayout.minOverlayHeight
+        }
+        let aspect = image.size.width / image.size.height
+        let height = OverlayLayout.overlayWidth / aspect
+        return min(max(height, OverlayLayout.minOverlayHeight), OverlayLayout.maxOverlayHeight)
+    }
 
     init(
         image: NSImage,
@@ -135,23 +227,17 @@ class OverlayWindow: NSPanel, NSDraggingSource, NSFilePromiseProviderDelegate {
         onCopy: @escaping () -> Void,
         onSave: @escaping () -> Void,
         onAnnotate: @escaping () -> Void,
-        onDelete: @escaping () -> Void,
-        onPauseDismiss: @escaping () -> Void,
-        onResumeDismiss: @escaping () -> Void,
-        onDragSuccess: @escaping () -> Void,
-        onDismiss: @escaping () -> Void
+        onDelete: @escaping () -> Void
     ) {
         self.image = image
         self.savedURL = savedURL
-        self.onPauseDismiss = onPauseDismiss
-        self.onResumeDismiss = onResumeDismiss
-        self.onDragSuccess = onDragSuccess
+        self.anchorScreen = preferredScreen ?? NSScreen.main
 
         let overlayWidth = OverlayLayout.overlayWidth
-        let overlayHeight = OverlayLayout.overlayHeight
+        let overlayHeight = Self.overlayHeight(for: image)
 
         // Define button exclusion zones (in window coordinates, origin bottom-left)
-        // Action bar: top-right corner (4 buttons now)
+        // Action bar: top-right corner (4 buttons)
         let actionBarWidth: CGFloat = 50
         let actionBarHeight: CGFloat = 156
         self.actionBarRect = NSRect(
@@ -163,7 +249,6 @@ class OverlayWindow: NSPanel, NSDraggingSource, NSFilePromiseProviderDelegate {
         // Close button: top-left corner
         self.closeButtonRect = NSRect(x: 0, y: overlayHeight - 40, width: 40, height: 40)
 
-        // Fixed size container; position above dock using visibleFrame
         guard let screen = preferredScreen ?? NSScreen.main else {
             super.init(
                 contentRect: .zero,
@@ -174,8 +259,6 @@ class OverlayWindow: NSPanel, NSDraggingSource, NSFilePromiseProviderDelegate {
             return
         }
 
-        let padding: CGFloat = 20
-
         // visibleFrame excludes dock and menu bar
         let visibleFrame = screen.visibleFrame
 
@@ -184,15 +267,14 @@ class OverlayWindow: NSPanel, NSDraggingSource, NSFilePromiseProviderDelegate {
         let xOffset: CGFloat
 
         if position == .bottomRight {
-            // Right edge minus overlay width minus padding
-            xOffset = visibleFrame.maxX - overlayWidth - padding
+            xOffset = visibleFrame.maxX - overlayWidth - OverlayLayout.screenPadding
         } else {
-            xOffset = visibleFrame.minX + padding
+            xOffset = visibleFrame.minX + OverlayLayout.screenPadding
         }
 
         let frame = NSRect(
             x: xOffset,
-            y: visibleFrame.minY + padding,
+            y: visibleFrame.minY + OverlayLayout.screenPadding,
             width: overlayWidth,
             height: overlayHeight
         )
@@ -207,6 +289,9 @@ class OverlayWindow: NSPanel, NSDraggingSource, NSFilePromiseProviderDelegate {
         // Configure panel
         self.isFloatingPanel = true
         self.level = .floating
+        // Follow the active space — including full-screen apps — so the
+        // overlay is visible wherever the capture was taken.
+        self.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
         self.isOpaque = false
         self.backgroundColor = .clear
         self.hasShadow = false
@@ -217,17 +302,34 @@ class OverlayWindow: NSPanel, NSDraggingSource, NSFilePromiseProviderDelegate {
         self.contentMinSize = NSSize(width: overlayWidth, height: overlayHeight)
         self.contentMaxSize = NSSize(width: overlayWidth, height: overlayHeight)
 
-        // Create SwiftUI view
+        // Create SwiftUI view; action closures route through this window so
+        // each overlay dismisses itself independently.
         let overlayView = OverlayView(
             image: image,
+            size: CGSize(width: overlayWidth, height: overlayHeight),
             hasSavedFile: savedURL != nil,
-            onCopy: onCopy,
+            onCopy: { [weak self] in
+                onCopy()
+                self?.flashCopySuccessAndDismiss()
+            },
             onSave: onSave,
-            onAnnotate: onAnnotate,
-            onDelete: onDelete,
-            onPauseDismiss: onPauseDismiss,
-            onResumeDismiss: onResumeDismiss,
-            onDismiss: onDismiss
+            onAnnotate: { [weak self] in
+                onAnnotate()
+                self?.requestDismiss()
+            },
+            onDelete: { [weak self] in
+                onDelete()
+                self?.requestDismiss()
+            },
+            onPauseDismiss: { [weak self] in
+                self?.pauseAutoDismiss()
+            },
+            onResumeDismiss: { [weak self] in
+                self?.resumeAutoDismiss()
+            },
+            onDismiss: { [weak self] in
+                self?.requestDismiss()
+            }
         )
 
         hostingView = NSHostingView(rootView: overlayView)
@@ -241,6 +343,38 @@ class OverlayWindow: NSPanel, NSDraggingSource, NSFilePromiseProviderDelegate {
 
     // Allow the panel to become key to receive mouse events properly
     override var canBecomeKey: Bool { true }
+
+    // MARK: - Auto-dismiss timer
+
+    func startAutoDismissTimer() {
+        dismissTimer?.invalidate()
+        let delay = PreferencesManager.shared.overlayAutoDismissDelay
+
+        // Don't create timer if delay is negative (never auto-dismiss)
+        guard delay > 0 else { return }
+
+        dismissTimer = Timer.scheduledTimer(withTimeInterval: delay, repeats: false) { [weak self] _ in
+            self?.requestDismiss()
+        }
+    }
+
+    func pauseAutoDismiss() {
+        dismissTimer?.invalidate()
+        dismissTimer = nil
+    }
+
+    func resumeAutoDismiss() {
+        startAutoDismissTimer()
+    }
+
+    private func requestDismiss() {
+        onRequestDismiss?()
+    }
+
+    /// Escape dismisses the overlay (when it has key status, e.g. after a click).
+    override func cancelOperation(_ sender: Any?) {
+        requestDismiss()
+    }
 
     // MARK: - Mouse handling for drag
 
@@ -292,14 +426,22 @@ class OverlayWindow: NSPanel, NSDraggingSource, NSFilePromiseProviderDelegate {
     }
 
     private func beginFileDrag(with event: NSEvent) {
-        onPauseDismiss()
+        pauseAutoDismiss()
 
         // Gray out the overlay while dragging
         self.alphaValue = 0.5
 
-        let provider = NSFilePromiseProvider(fileType: UTType.png.identifier, delegate: self)
-        currentPromiseFilename = savedURL?.lastPathComponent ?? FileNaming.generateFilename(extension: "png")
+        // The drag source outlives this window so slow drop targets still
+        // get their file after the overlay is dismissed.
+        let source = ScreenshotDragSource(
+            image: image,
+            savedURL: savedURL,
+            filename: savedURL?.lastPathComponent ?? FileNaming.generateFilename(extension: "png")
+        )
+        source.retainUntilFulfilled()
+        currentDragSource = source
 
+        let provider = NSFilePromiseProvider(fileType: UTType.png.identifier, delegate: source)
         let draggingItem = NSDraggingItem(pasteboardWriter: provider)
 
         // Create a smaller drag image (like CleanShot)
@@ -335,55 +477,16 @@ class OverlayWindow: NSPanel, NSDraggingSource, NSFilePromiseProviderDelegate {
         self.alphaValue = 1.0
 
         if operation != [] {
-            onDragSuccess()
+            // Dropped: the retained drag source fulfills the promise even
+            // after this window is gone.
+            currentDragSource = nil
+            requestDismiss()
         } else {
-            onResumeDismiss()
+            // No drop happened - nothing will ask for the file
+            currentDragSource?.release()
+            currentDragSource = nil
+            resumeAutoDismiss()
         }
-    }
-
-    // MARK: - NSFilePromiseProviderDelegate
-
-    func filePromiseProvider(_ filePromiseProvider: NSFilePromiseProvider, fileNameForType fileType: String) -> String {
-        currentPromiseFilename ?? savedURL?.lastPathComponent ?? FileNaming.generateFilename(extension: "png")
-    }
-
-    func filePromiseProvider(
-        _ filePromiseProvider: NSFilePromiseProvider,
-        writePromiseTo url: URL,
-        completionHandler: @escaping (Error?) -> Void
-    ) {
-        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-            guard let self = self else {
-                completionHandler(DragExportError.sourceUnavailable)
-                return
-            }
-            do {
-                try self.writePromise(to: url)
-                completionHandler(nil)
-            } catch {
-                completionHandler(error)
-            }
-        }
-    }
-
-    private func writePromise(to destinationURL: URL) throws {
-        let fileManager = FileManager.default
-
-        if let savedURL = savedURL, fileManager.fileExists(atPath: savedURL.path) {
-            if fileManager.fileExists(atPath: destinationURL.path) {
-                try fileManager.removeItem(at: destinationURL)
-            }
-            try fileManager.copyItem(at: savedURL, to: destinationURL)
-            return
-        }
-
-        // Fall back to converting image to PNG
-        guard let tiffData = image.tiffRepresentation,
-              let bitmap = NSBitmapImageRep(data: tiffData),
-              let pngData = bitmap.representation(using: .png, properties: [:]) else {
-            throw DragExportError.imageConversionFailed
-        }
-        try pngData.write(to: destinationURL, options: .atomic)
     }
 
     // MARK: - Window lifecycle
@@ -400,6 +503,9 @@ class OverlayWindow: NSPanel, NSDraggingSource, NSFilePromiseProviderDelegate {
     }
 
     override func close() {
+        dismissTimer?.invalidate()
+        dismissTimer = nil
+
         // Animate out
         NSAnimationContext.runAnimationGroup({ context in
             context.duration = 0.15
@@ -409,7 +515,9 @@ class OverlayWindow: NSPanel, NSDraggingSource, NSFilePromiseProviderDelegate {
         })
     }
 
-    func flashCopySuccess() {
+    /// Brief visual confirmation that the copy happened, then dismiss.
+    private func flashCopySuccessAndDismiss() {
+        pauseAutoDismiss()
         NSAnimationContext.runAnimationGroup({ context in
             context.duration = 0.1
             self.animator().alphaValue = 0.5
@@ -419,11 +527,15 @@ class OverlayWindow: NSPanel, NSDraggingSource, NSFilePromiseProviderDelegate {
                 self.animator().alphaValue = 1
             }
         })
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) { [weak self] in
+            self?.requestDismiss()
+        }
     }
 }
 
 struct OverlayView: View {
     let image: NSImage
+    let size: CGSize
     let hasSavedFile: Bool
     let onCopy: () -> Void
     let onSave: () -> Void
@@ -436,15 +548,17 @@ struct OverlayView: View {
     @State private var isHovering = false
 
     var body: some View {
-        // Image fills the fixed container (crops if needed), buttons anchor to image edges
+        // Material card with the capture letterboxed inside, so the whole
+        // capture is always visible regardless of aspect ratio
         ZStack {
+            ActiveVisualEffectView(material: .hudWindow)
             Image(nsImage: image)
                 .resizable()
-                .aspectRatio(contentMode: .fill)
-                .frame(width: OverlayLayout.overlayWidth, height: OverlayLayout.overlayHeight)
+                .aspectRatio(contentMode: .fit)
+                .frame(width: size.width, height: size.height)
                 .allowsHitTesting(false)
         }
-        .frame(width: OverlayLayout.overlayWidth, height: OverlayLayout.overlayHeight)
+        .frame(width: size.width, height: size.height)
         .clipShape(RoundedRectangle(cornerRadius: 10))
         .overlay(
             RoundedRectangle(cornerRadius: 10)
@@ -566,6 +680,7 @@ struct ActiveVisualEffectView: NSViewRepresentable {
 #Preview {
     OverlayView(
         image: NSImage(systemSymbolName: "photo", accessibilityDescription: nil)!,
+        size: CGSize(width: 280, height: 180),
         hasSavedFile: true,
         onCopy: {},
         onSave: {},

--- a/Shotter/Sources/Preferences/PreferencesView.swift
+++ b/Shotter/Sources/Preferences/PreferencesView.swift
@@ -100,12 +100,16 @@ struct PreferencesView: View {
                         ))
                         Spacer()
                         if prefs.shortcutWindow.isEnabled {
-                            ShortcutBadge(shortcut: prefs.shortcutWindow)
-                            Button("Change") {
-                                recordingShortcut = .window
+                            if recordingShortcut == .window {
+                                ShortcutRecorder(shortcut: $prefs.shortcutWindow, onComplete: { recordingShortcut = nil })
+                            } else {
+                                ShortcutBadge(shortcut: prefs.shortcutWindow)
+                                Button("Change") {
+                                    recordingShortcut = .window
+                                }
+                                .buttonStyle(.borderless)
+                                .font(.caption)
                             }
-                            .buttonStyle(.borderless)
-                            .font(.caption)
                         }
                     }
                     Text("Optional: Skip area selection and go straight to window mode")

--- a/Shotter/Sources/Utils/Permissions.swift
+++ b/Shotter/Sources/Utils/Permissions.swift
@@ -9,11 +9,22 @@ struct Permissions {
 
     // MARK: - Cached State
 
+    // The cache is read from the CGEvent tap thread and written from async
+    // tasks — all access goes through cacheLock.
+    private static let cacheLock = NSLock()
     private static var cachedScreenRecording: Bool?
     private static var cachedAccessibility: Bool?
     private static var lastScreenRecordingCheck: Date?
     private static var lastAccessibilityCheck: Date?
     private static let cacheInterval: TimeInterval = 30 // Refresh every 30 seconds
+
+    private static func cachedValue(_ value: Bool?, lastCheck: Date?) -> Bool? {
+        guard let value, let lastCheck,
+              Date().timeIntervalSince(lastCheck) < cacheInterval else {
+            return nil
+        }
+        return value
+    }
 
     // MARK: - Screen Recording
 
@@ -23,37 +34,48 @@ struct Permissions {
         }
 
         // Return cached value if recent
-        if let cached = cachedScreenRecording,
-           let lastCheck = lastScreenRecordingCheck,
-           Date().timeIntervalSince(lastCheck) < cacheInterval {
+        if let cached = cachedScreenRecordingValue() {
             return cached
         }
 
         do {
             // Attempting to get shareable content will trigger permission prompt if needed
             _ = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: true)
-            cachedScreenRecording = true
-            lastScreenRecordingCheck = Date()
+            storeScreenRecordingResult(true)
             return true
         } catch {
-            cachedScreenRecording = false
-            lastScreenRecordingCheck = Date()
+            storeScreenRecordingResult(false)
             return false
         }
     }
 
+    /// Synchronous locked read of the screen-recording cache (async-context safe).
+    private static func cachedScreenRecordingValue() -> Bool? {
+        cacheLock.lock()
+        defer { cacheLock.unlock() }
+        return cachedValue(cachedScreenRecording, lastCheck: lastScreenRecordingCheck)
+    }
+
     static func checkScreenRecordingSync(forceRefresh: Bool = false) -> Bool {
-        if !forceRefresh,
-           let cached = cachedScreenRecording,
-           let lastCheck = lastScreenRecordingCheck,
-           Date().timeIntervalSince(lastCheck) < cacheInterval {
-            return cached
+        if !forceRefresh {
+            cacheLock.lock()
+            let cached = cachedValue(cachedScreenRecording, lastCheck: lastScreenRecordingCheck)
+            cacheLock.unlock()
+            if let cached {
+                return cached
+            }
         }
 
         let result = CGPreflightScreenCaptureAccess()
+        storeScreenRecordingResult(result)
+        return result
+    }
+
+    private static func storeScreenRecordingResult(_ result: Bool) {
+        cacheLock.lock()
         cachedScreenRecording = result
         lastScreenRecordingCheck = Date()
-        return result
+        cacheLock.unlock()
     }
     
     static func requestScreenRecording() async {
@@ -74,17 +96,20 @@ struct Permissions {
     
     static func checkAccessibility() -> Bool {
         // Return cached value if recent
-        if let cached = cachedAccessibility,
-           let lastCheck = lastAccessibilityCheck,
-           Date().timeIntervalSince(lastCheck) < cacheInterval {
+        cacheLock.lock()
+        let cached = cachedValue(cachedAccessibility, lastCheck: lastAccessibilityCheck)
+        cacheLock.unlock()
+        if let cached {
             return cached
         }
 
         // Check if we have accessibility permissions
         let options: NSDictionary = [kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: false]
         let result = AXIsProcessTrustedWithOptions(options)
+        cacheLock.lock()
         cachedAccessibility = result
         lastAccessibilityCheck = Date()
+        cacheLock.unlock()
         return result
     }
     
@@ -106,9 +131,11 @@ struct Permissions {
     }
     
     static func invalidateCache() {
+        cacheLock.lock()
         cachedScreenRecording = nil
         cachedAccessibility = nil
         lastScreenRecordingCheck = nil
         lastAccessibilityCheck = nil
+        cacheLock.unlock()
     }
 }


### PR DESCRIPTION
Fixes all confirmed bugs from the 2026-07-02 multi-agent code review (see thoughts/plans/2026-07-02-ultra-review-fix-plan.md locally for the full review).

Highlights:
- Capture re-entrancy guard: double hotkey press no longer wedges the app
- Shotter's own overlay windows excluded from captures
- Post-capture overlays stack (up to 5), show over full-screen apps, aspect-fit thumbnails, Escape to dismiss
- Drag-and-drop file promise survives overlay dismissal (empty-file fix for Mail/slow targets)
- Editor undo overhaul: crops undoable, no stray "Text" placeholder baked into saves, text editor no longer vertically mirrored
- Hotkeys recover automatically after granting Accessibility (no relaunch)
- Direct Window shortcut recorder, window-picker hover brighten, thread-safe permission cache, OCR coordinate fix

Manually tested on a signed v1.7.4 build installed to /Applications: re-entrancy, stacking, text placement, crop undo, and the shortcut recorder all verified.

Known follow-up: #69 (text field doesn't grab keyboard focus — pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)