### PR TITLE
Add Pin to Screen (floating always-on-top captures)

### DIFF
--- a/Shotter/Sources/App/ShotterApp.swift
+++ b/Shotter/Sources/App/ShotterApp.swift
@@ -35,6 +35,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var hotkeyManager: HotkeyManager?
     private var captureEngine: CaptureEngine?
     private var overlayController: OverlayController?
+    private let pinnedWindowController = PinnedWindowController()
     private var preferencesWindow: NSWindow?
     
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -200,6 +201,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                         DebugLogger.log("Overlay annotate clicked (savedURL available)")
                         self.openAnnotationEditor(image: image, savedURL: savedURL, preferredScreen: preferredScreen)
                     },
+                    onPin: {
+                        self.pinnedWindowController.pin(image: image, near: preferredScreen)
+                    },
                     onDelete: {
                         self.moveToTrash(savedURL)
                     }
@@ -239,6 +243,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             onAnnotate: {
                 DebugLogger.log("Overlay annotate clicked (manual save mode)")
                 self.openAnnotationEditor(image: image, savedURL: nil, preferredScreen: preferredScreen)
+            },
+            onPin: {
+                self.pinnedWindowController.pin(image: image, near: preferredScreen)
             },
             onDelete: {
                 // No file exists - the overlay dismisses itself

--- a/Shotter/Sources/Overlay/OverlayController.swift
+++ b/Shotter/Sources/Overlay/OverlayController.swift
@@ -40,6 +40,7 @@ class OverlayController {
         onCopy: @escaping () -> Void,
         onSave: @escaping () -> Void,
         onAnnotate: @escaping () -> Void,
+        onPin: @escaping () -> Void,
         onDelete: @escaping () -> Void
     ) -> () -> Void {
         // Cap the stack; drop the oldest overlay when full
@@ -54,6 +55,7 @@ class OverlayController {
             onCopy: onCopy,
             onSave: onSave,
             onAnnotate: onAnnotate,
+            onPin: onPin,
             onDelete: onDelete
         )
         window.onRequestDismiss = { [weak self, weak window] in
@@ -227,6 +229,7 @@ class OverlayWindow: NSPanel, NSDraggingSource {
         onCopy: @escaping () -> Void,
         onSave: @escaping () -> Void,
         onAnnotate: @escaping () -> Void,
+        onPin: @escaping () -> Void,
         onDelete: @escaping () -> Void
     ) {
         self.image = image
@@ -237,9 +240,9 @@ class OverlayWindow: NSPanel, NSDraggingSource {
         let overlayHeight = Self.overlayHeight(for: image)
 
         // Define button exclusion zones (in window coordinates, origin bottom-left)
-        // Action bar: top-right corner (4 buttons)
+        // Action bar: top-right corner (5 buttons)
         let actionBarWidth: CGFloat = 50
-        let actionBarHeight: CGFloat = 156
+        let actionBarHeight: CGFloat = 192
         self.actionBarRect = NSRect(
             x: overlayWidth - actionBarWidth - OverlayLayout.actionBarOuterPadding,
             y: overlayHeight - actionBarHeight - OverlayLayout.actionBarOuterPadding,
@@ -315,6 +318,10 @@ class OverlayWindow: NSPanel, NSDraggingSource {
             onSave: onSave,
             onAnnotate: { [weak self] in
                 onAnnotate()
+                self?.requestDismiss()
+            },
+            onPin: { [weak self] in
+                onPin()
                 self?.requestDismiss()
             },
             onDelete: { [weak self] in
@@ -540,6 +547,7 @@ struct OverlayView: View {
     let onCopy: () -> Void
     let onSave: () -> Void
     let onAnnotate: () -> Void
+    let onPin: () -> Void
     let onDelete: () -> Void
     let onPauseDismiss: () -> Void
     let onResumeDismiss: () -> Void
@@ -580,6 +588,9 @@ struct OverlayView: View {
                 OverlayActionButton(systemName: "pencil.tip.crop.circle", action: onAnnotate)
                     .help("Annotate")
                     .accessibilityLabel(Text("Annotate"))
+                OverlayActionButton(systemName: "pin", action: onPin)
+                    .help("Pin to screen")
+                    .accessibilityLabel(Text("Pin to screen"))
                 // Show "Discard" when no file exists, "Move to Trash" when file exists
                 OverlayDeleteButton(action: onDelete)
                     .help(hasSavedFile ? "Move to Trash" : "Discard")
@@ -685,6 +696,7 @@ struct ActiveVisualEffectView: NSViewRepresentable {
         onCopy: {},
         onSave: {},
         onAnnotate: {},
+        onPin: {},
         onDelete: {},
         onPauseDismiss: {},
         onResumeDismiss: {},

--- a/Shotter/Sources/Overlay/PinnedWindowController.swift
+++ b/Shotter/Sources/Overlay/PinnedWindowController.swift
@@ -1,0 +1,207 @@
+import AppKit
+import SwiftUI
+
+/// Manages floating "pinned" screenshot windows that stay on top of every
+/// other app, so a capture can be kept on screen as a reference while working.
+final class PinnedWindowController {
+    private var windows: [PinnedWindow] = []
+
+    /// Pins `image` as a new always-on-top floating window near `screen`.
+    @discardableResult
+    func pin(image: NSImage, near screen: NSScreen?) -> PinnedWindow {
+        let window = PinnedWindow(
+            image: image,
+            preferredScreen: screen,
+            cascadeIndex: windows.count
+        )
+        window.onClosed = { [weak self, weak window] in
+            guard let self, let window else { return }
+            self.windows.removeAll { $0 === window }
+        }
+        windows.append(window)
+        window.show()
+        DebugLogger.log("Pinned screenshot (\(windows.count) pinned)")
+        return window
+    }
+
+    /// Closes every pinned window (used on quit / cleanup).
+    func closeAll() {
+        windows.forEach { $0.close() }
+        windows.removeAll()
+    }
+}
+
+// MARK: - Pinned Window
+
+final class PinnedWindow: NSPanel {
+    private let image: NSImage
+    private var hostingView: NSHostingView<PinnedView>?
+    private var isClosing = false
+
+    /// Called once when the window has finished closing, so the controller
+    /// can drop its reference.
+    var onClosed: (() -> Void)?
+
+    /// Longest on-screen side of a freshly pinned window, in points. Images
+    /// smaller than this are never upscaled.
+    private static let maxPinnedSide: CGFloat = 480
+
+    init(image: NSImage, preferredScreen: NSScreen?, cascadeIndex: Int) {
+        self.image = image
+
+        let screen = preferredScreen ?? NSScreen.main
+        let visible = screen?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1440, height: 900)
+
+        // Scale so the longest side fits a comfortable pinned size (never upscale).
+        let longest = max(image.size.width, image.size.height, 1)
+        let scale = min(1, Self.maxPinnedSide / longest)
+        let width = max(image.size.width * scale, 80)
+        let height = max(image.size.height * scale, 60)
+
+        // Cascade so several pins don't land exactly on top of each other.
+        let step = CGFloat(cascadeIndex % 8) * 28
+        let origin = NSPoint(
+            x: visible.midX - width / 2 + step,
+            y: visible.midY - height / 2 - step
+        )
+
+        super.init(
+            contentRect: NSRect(origin: origin, size: CGSize(width: width, height: height)),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+
+        self.isFloatingPanel = true
+        self.level = .floating
+        // Stay visible across spaces and full-screen apps.
+        self.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        self.isOpaque = false
+        self.backgroundColor = .clear
+        self.hasShadow = true
+        self.isMovableByWindowBackground = true
+        self.hidesOnDeactivate = false
+
+        let view = PinnedView(
+            image: image,
+            size: CGSize(width: width, height: height),
+            onCopy: { [weak self] in self?.copyToClipboard() },
+            onClose: { [weak self] in self?.close() }
+        )
+        let hosting = NSHostingView(rootView: view)
+        hosting.frame = NSRect(x: 0, y: 0, width: width, height: height)
+        self.hostingView = hosting
+        self.contentView = hosting
+    }
+
+    override var canBecomeKey: Bool { true }
+
+    func show() {
+        orderFrontRegardless()
+        alphaValue = 0
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0.18
+            animator().alphaValue = 1
+        }
+    }
+
+    /// Escape unpins the window when it has key status.
+    override func cancelOperation(_ sender: Any?) {
+        close()
+    }
+
+    override func close() {
+        // Guard against re-entrancy (Escape + close button, or double close).
+        guard !isClosing else { return }
+        isClosing = true
+        onClosed?()
+        onClosed = nil
+
+        NSAnimationContext.runAnimationGroup({ context in
+            context.duration = 0.12
+            animator().alphaValue = 0
+        }, completionHandler: {
+            super.close()
+        })
+    }
+
+    private func copyToClipboard() {
+        guard let tiffData = image.tiffRepresentation,
+              let bitmap = NSBitmapImageRep(data: tiffData),
+              let pngData = bitmap.representation(using: .png, properties: [:]) else {
+            DebugLogger.log("Pinned copy failed: could not convert image")
+            return
+        }
+
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.declareTypes([.png, .tiff], owner: nil)
+        pasteboard.setData(pngData, forType: .png)
+        pasteboard.setData(tiffData, forType: .tiff)
+
+        // Brief flash to confirm the copy.
+        NSAnimationContext.runAnimationGroup({ context in
+            context.duration = 0.1
+            animator().alphaValue = 0.6
+        }, completionHandler: { [weak self] in
+            NSAnimationContext.runAnimationGroup { context in
+                context.duration = 0.1
+                self?.animator().alphaValue = 1
+            }
+        })
+    }
+}
+
+// MARK: - Pinned View
+
+struct PinnedView: View {
+    let image: NSImage
+    let size: CGSize
+    let onCopy: () -> Void
+    let onClose: () -> Void
+
+    @State private var isHovering = false
+
+    var body: some View {
+        Image(nsImage: image)
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+            .frame(width: size.width, height: size.height)
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(Color.white.opacity(0.18), lineWidth: 1)
+            )
+            .overlay(alignment: .topLeading) {
+                if isHovering {
+                    Button(action: onClose) {
+                        Image(systemName: "xmark.circle.fill")
+                            .font(.system(size: 17))
+                            .foregroundStyle(.white.opacity(0.9))
+                            .background(Circle().fill(Color.black.opacity(0.55)))
+                    }
+                    .buttonStyle(.plain)
+                    .padding(8)
+                    .help("Unpin")
+                    .accessibilityLabel(Text("Unpin"))
+                }
+            }
+            .overlay(alignment: .topTrailing) {
+                if isHovering {
+                    Button(action: onCopy) {
+                        Image(systemName: "doc.on.doc.fill")
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundStyle(.white.opacity(0.9))
+                            .frame(width: 26, height: 26)
+                            .background(Circle().fill(Color.black.opacity(0.55)))
+                    }
+                    .buttonStyle(.plain)
+                    .padding(8)
+                    .help("Copy")
+                    .accessibilityLabel(Text("Copy"))
+                }
+            }
+            .shadow(radius: 10)
+            .onHover { isHovering = $0 }
+    }
+}


### PR DESCRIPTION
## What & why

Phase 4 parity feature #1: **Pin to Screen** — keep a capture floating on top of every app as a reference while you work (CleanShot's signature feature).

## How it works
- A **pin button** appears in the capture overlay's action bar
- Clicking it opens a borderless, always-on-top floating window showing the screenshot
- **Move** it by dragging the image; **hover** reveals copy (top-right) and close/unpin (top-left) buttons; **Escape** unpins when focused
- Multiple pins **cascade** so they don't land exactly on top of each other
- Joins all spaces + full-screen apps so it stays visible everywhere

## Implementation
- New `PinnedWindowController` + `PinnedWindow: NSPanel` + `PinnedView` (SwiftUI)
- `onPin` threaded through `OverlayController.showOverlay` → `OverlayWindow` → `OverlayView`
- Bumped the overlay's click-exclusion zone (156→192pt) for the 5th action button
- Wired `pinnedWindowController.pin(...)` into both overlay call sites in `ShotterApp`

## Scope note
This version is **move + copy + close**. Dragging the pinned image *directly into another app* was deferred — that gesture conflicts with drag-to-move and needs more careful interaction design.

## Testing
- `swift build -c release` clean, no warnings
- Signed build installed; pinned a capture, verified always-on-top, move, copy, close, Escape, and cascade

🤖 Generated with [Claude Code](https://claude.com/claude-code)