### PR TITLE
Add background beautify frame to annotation editor

### DIFF
--- a/Shotter/Sources/Annotations/AnnotationCanvasView.swift
+++ b/Shotter/Sources/Annotations/AnnotationCanvasView.swift
@@ -94,16 +94,25 @@ class AnnotationCanvasView: NSView {
         // Clear background
         context.setFillColor(NSColor.controlBackgroundColor.cgColor)
         context.fill(bounds)
-        
-        // Calculate image position (centered)
-        let imageRect = imageRectInView()
-        
-        // Draw checkerboard pattern behind image (for transparency)
-        drawCheckerboard(in: imageRect, context: context)
-        
-        // Draw base image
-        state.baseImage.draw(in: imageRect)
-        
+
+        // Resolve beautify geometry (screenshot content rect + frame).
+        let layout = beautifyLayout(viewSize: bounds.size, imageSize: state.imageSize, style: state.background)
+        scale = layout.scale
+        let imageRect = layout.contentRect
+
+        if state.background.isActive {
+            // Composite background, shadow, and window chrome around the screenshot.
+            BackgroundRenderer.drawBeautified(
+                in: context, layout: layout, style: state.background, imageSize: state.imageSize
+            ) { rect in
+                state.baseImage.draw(in: rect)
+            }
+        } else {
+            // Checkerboard behind image (for transparency), then the screenshot.
+            drawCheckerboard(in: imageRect, context: context)
+            state.baseImage.draw(in: imageRect)
+        }
+
         // Draw blur regions
         for anyAnnotation in state.annotations {
             if let blurAnnotation = anyAnnotation.annotation as? BlurAnnotation {
@@ -161,9 +170,9 @@ class AnnotationCanvasView: NSView {
     private func imageRectInView() -> CGRect {
         guard let state = state else { return .zero }
 
-        let imageRect = annotationImageRect(in: bounds.size, imageSize: state.imageSize)
-        scale = imageRect.width / state.imageSize.width
-        return imageRect
+        let layout = beautifyLayout(viewSize: bounds.size, imageSize: state.imageSize, style: state.background)
+        scale = layout.scale
+        return layout.contentRect
     }
     
     private func drawCheckerboard(in rect: CGRect, context: CGContext) {

--- a/Shotter/Sources/Annotations/AnnotationEditorState.swift
+++ b/Shotter/Sources/Annotations/AnnotationEditorState.swift
@@ -20,6 +20,12 @@ class AnnotationEditorState: ObservableObject {
     @Published var displayScale: CGFloat = 1
     @Published private(set) var canvasFocusRequestID: Int = 0
 
+    /// Beautify presentation frame (background, padding, corners, shadow, window
+    /// chrome) composited around the annotated screenshot. Persisted between captures.
+    @Published var background: BackgroundStyle = BackgroundStore.load() {
+        didSet { BackgroundStore.save(background) }
+    }
+
     // Modifier keys
     var isShiftKeyHeld: Bool = false
     
@@ -53,7 +59,28 @@ class AnnotationEditorState: ObservableObject {
 
     /// Whether the editor has changes worth prompting about on close
     var hasUnsavedChanges: Bool {
-        !annotations.isEmpty || hasBeenCropped
+        !annotations.isEmpty || hasBeenCropped || background.isActive
+    }
+
+    /// Pixel dimensions of the exported image (beautify frame included).
+    var outputPixelSize: CGSize {
+        let px = baseImagePixelScale
+        if !background.isActive {
+            return CGSize(width: (imageSize.width * px).rounded(),
+                          height: (imageSize.height * px).rounded())
+        }
+        let refDim = max(imageSize.width, imageSize.height)
+        let padPts = CGFloat(background.paddingFraction) * refDim
+        let titlePts = background.titleBarHeight(imageWidth: imageSize.width)
+        return CGSize(width: ((imageSize.width + 2 * padPts) * px).rounded(),
+                      height: ((imageSize.height + titlePts + 2 * padPts) * px).rounded())
+    }
+
+    /// Retina pixel density of the base screenshot (2.0 on most displays).
+    private var baseImagePixelScale: CGFloat {
+        guard let cg = baseImage.cgImage(forProposedRect: nil, context: nil, hints: nil),
+              imageSize.width > 0 else { return 1 }
+        return max(1, CGFloat(cg.width) / imageSize.width)
     }
 
     // Cached CIContext for blur operations (expensive to create)
@@ -391,8 +418,16 @@ class AnnotationEditorState: ObservableObject {
 
     // MARK: - Rendering
     
-    /// Render the final image with all annotations
+    /// Render the final exported image: annotations flattened onto the
+    /// screenshot, then wrapped in the beautify frame (if active).
     func renderFinalImage() -> NSImage? {
+        guard let annotated = renderAnnotatedScreenshot() else { return nil }
+        guard background.isActive else { return annotated }
+        return BackgroundRenderer.renderBeautified(annotated: annotated, imageSize: imageSize, style: background)
+    }
+
+    /// Render the screenshot with all annotations flattened, at native size.
+    private func renderAnnotatedScreenshot() -> NSImage? {
         let size = baseImage.size
         
         let image = NSImage(size: size)

--- a/Shotter/Sources/Annotations/AnnotationEditorWindow.swift
+++ b/Shotter/Sources/Annotations/AnnotationEditorWindow.swift
@@ -348,7 +348,7 @@ struct AnnotationEditorView: View {
                     if state.editingTextAnnotationId != nil {
                         TextEditorOverlay(
                             state: state,
-                            imageRect: annotationImageRect(in: geometry.size, imageSize: state.imageSize),
+                            imageRect: beautifyLayout(viewSize: geometry.size, imageSize: state.imageSize, style: state.background).contentRect,
                             scale: calculateScale(for: geometry.size)
                         )
                     }
@@ -369,15 +369,9 @@ struct AnnotationEditorView: View {
     }
     
     private func calculateScale(for viewSize: CGSize) -> CGFloat {
-        let imageSize = state.imageSize
-        let imageAspect = imageSize.width / imageSize.height
-        let viewAspect = viewSize.width / viewSize.height
-        
-        if imageAspect > viewAspect {
-            return viewSize.width / imageSize.width
-        } else {
-            return viewSize.height / imageSize.height
-        }
+        // The screenshot's on-screen zoom equals the beautify layout scale
+        // (identical to a plain aspect-fit when beautify is inactive).
+        beautifyLayout(viewSize: viewSize, imageSize: state.imageSize, style: state.background).scale
     }
 }
 
@@ -410,6 +404,9 @@ struct AnnotationToolbar: View {
                 RoundedRectangle(cornerRadius: 9)
                     .stroke(Color.primary.opacity(0.08), lineWidth: 1)
             )
+
+            // Beautify / background frame
+            BackgroundButton(state: state)
 
             Spacer()
 
@@ -758,6 +755,16 @@ struct ColorPillButton: View {
 struct EditorStatusBar: View {
     @ObservedObject var state: AnnotationEditorState
 
+    /// Beautified canvas size in the screenshot's own units (points).
+    private var displaySize: CGSize {
+        let img = state.imageSize
+        guard state.background.isActive else { return img }
+        let refDim = max(img.width, img.height)
+        let pad = CGFloat(state.background.paddingFraction) * refDim
+        let title = state.background.titleBarHeight(imageWidth: img.width)
+        return CGSize(width: img.width + 2 * pad, height: img.height + title + 2 * pad)
+    }
+
     var body: some View {
         HStack(spacing: 8) {
             // Zoom percentage (bottom-left)
@@ -775,12 +782,13 @@ struct EditorStatusBar: View {
 
             Spacer()
 
-            // Image dimensions (bottom-right)
-            Text("\(Int(state.imageSize.width.rounded())) × \(Int(state.imageSize.height.rounded()))")
+            // Output dimensions (bottom-right) — includes beautify frame when active
+            Text("\(Int(displaySize.width.rounded())) × \(Int(displaySize.height.rounded()))")
                 .font(.system(size: 11, design: .rounded))
                 .monospacedDigit()
                 .foregroundColor(.secondary)
                 .frame(minWidth: 52, alignment: .trailing)
+                .help(state.background.isActive ? "Exported size (with background)" : "Screenshot size")
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 6)

--- a/Shotter/Sources/Annotations/BackgroundPanel.swift
+++ b/Shotter/Sources/Annotations/BackgroundPanel.swift
@@ -1,0 +1,276 @@
+import AppKit
+import SwiftUI
+
+// MARK: - Toolbar Button
+
+/// Pill button in the editor toolbar that opens the beautify/background panel.
+struct BackgroundButton: View {
+    @ObservedObject var state: AnnotationEditorState
+
+    @State private var showingPanel = false
+    @State private var isHovered = false
+
+    private var isActive: Bool { state.background.isActive }
+
+    var body: some View {
+        Button(action: { showingPanel.toggle() }) {
+            HStack(spacing: 5) {
+                BackgroundPreviewSwatch(style: state.background, size: 16)
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundColor(.secondary)
+            }
+            .padding(.horizontal, 8)
+            .frame(height: 30)
+            .background(
+                RoundedRectangle(cornerRadius: 7)
+                    .fill(isActive ? Color.accentColor.opacity(isHovered ? 0.22 : 0.15)
+                                   : Color.primary.opacity(isHovered ? 0.12 : 0.06))
+            )
+            .foregroundColor(isActive ? Color.accentColor : .primary)
+        }
+        .buttonStyle(.plain)
+        .fixedSize()
+        .onHover { isHovered = $0 }
+        .help("Add a background, padding, and window frame")
+        .accessibilityLabel(Text("Background style"))
+        .popover(isPresented: $showingPanel, arrowEdge: .bottom) {
+            BackgroundPanel(state: state)
+        }
+    }
+}
+
+/// A tiny rounded preview of the current background (gradient / solid / none).
+struct BackgroundPreviewSwatch: View {
+    let style: BackgroundStyle
+    var size: CGFloat = 16
+
+    var body: some View {
+        RoundedRectangle(cornerRadius: 4)
+            .fill(fill)
+            .frame(width: size, height: size)
+            .overlay(
+                RoundedRectangle(cornerRadius: 4)
+                    .stroke(Color.primary.opacity(0.2), lineWidth: 1)
+            )
+            .overlay {
+                if case .none = style.kind {
+                    Image(systemName: "circle.slash")
+                        .font(.system(size: size * 0.7))
+                        .foregroundColor(.secondary)
+                }
+            }
+    }
+
+    private var fill: AnyShapeStyle {
+        switch style.kind {
+        case .none:
+            return AnyShapeStyle(Color.primary.opacity(0.05))
+        case .solid:
+            return AnyShapeStyle(Color(nsColor: style.solidColor))
+        case .gradient:
+            let colors = style.gradient.colors.map { Color(nsColor: $0) }
+            return AnyShapeStyle(LinearGradient(colors: colors, startPoint: .topLeading, endPoint: .bottomTrailing))
+        }
+    }
+}
+
+// MARK: - Panel
+
+struct BackgroundPanel: View {
+    @ObservedObject var state: AnnotationEditorState
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack {
+                Text("Background")
+                    .font(.system(size: 13, weight: .semibold))
+                Spacer()
+                Button("Reset") { state.background = .disabled }
+                    .buttonStyle(.plain)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(.accentColor)
+                    .disabled(!state.background.isActive)
+            }
+
+            // Fill selection
+            sectionHeader("Fill")
+            fillSwatches
+
+            Divider()
+
+            // Frame
+            sectionHeader("Window Frame")
+            frameControls
+
+            Divider()
+
+            // Sliders
+            slider("Padding", value: paddingBinding, range: 0...0.22)
+            slider("Corners", value: cornerBinding, range: 0...0.08)
+            slider("Shadow", value: shadowBinding, range: 0...1)
+        }
+        .padding(16)
+        .frame(width: 300)
+    }
+
+    // MARK: Fill swatches
+
+    private var fillSwatches: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            // Row 1: None + solids
+            let cols = [GridItem(.adaptive(minimum: 30, maximum: 30), spacing: 8)]
+            LazyVGrid(columns: cols, alignment: .leading, spacing: 8) {
+                // None
+                SwatchButton(isSelected: state.background.kind == .none) {
+                    state.background.kind = .none
+                } content: {
+                    Image(systemName: "circle.slash")
+                        .font(.system(size: 16))
+                        .foregroundColor(.secondary)
+                }
+
+                ForEach(SolidPreset.hexes, id: \.self) { hex in
+                    SwatchButton(isSelected: state.background.kind == .solid && state.background.solidHex == hex) {
+                        state.background.kind = .solid
+                        state.background.solidHex = hex
+                    } content: {
+                        RoundedRectangle(cornerRadius: 5)
+                            .fill(Color(nsColor: NSColor(hex: hex)))
+                    }
+                }
+            }
+
+            // Row 2: gradients
+            LazyVGrid(columns: cols, alignment: .leading, spacing: 8) {
+                ForEach(GradientPreset.all) { preset in
+                    SwatchButton(isSelected: state.background.kind == .gradient && state.background.gradientID == preset.id) {
+                        state.background.kind = .gradient
+                        state.background.gradientID = preset.id
+                    } content: {
+                        RoundedRectangle(cornerRadius: 5)
+                            .fill(LinearGradient(colors: preset.colors.map { Color(nsColor: $0) },
+                                                 startPoint: .topLeading, endPoint: .bottomTrailing))
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: Frame
+
+    private var frameControls: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 6) {
+                frameChip("None", isSelected: state.background.frame == .none) {
+                    state.background.frame = .none
+                }
+                frameChip("macOS", isSelected: state.background.frame.isMacOS) {
+                    state.background.frame = state.background.frame.isDark ? .macOSDark : .macOSLight
+                }
+                frameChip("Browser", isSelected: state.background.frame.isBrowser) {
+                    state.background.frame = state.background.frame.isDark ? .browserDark : .browserLight
+                }
+            }
+
+            if state.background.frame != .none {
+                Picker("", selection: darkBinding) {
+                    Text("Light").tag(false)
+                    Text("Dark").tag(true)
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+            }
+        }
+    }
+
+    private func frameChip(_ title: String, isSelected: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(title)
+                .font(.system(size: 11, weight: .medium))
+                .padding(.horizontal, 12)
+                .frame(height: 26)
+                .frame(maxWidth: .infinity)
+                .background(
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(isSelected ? Color.accentColor : Color.primary.opacity(0.06))
+                )
+                .foregroundColor(isSelected ? .white : .primary)
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: Helpers
+
+    private func sectionHeader(_ title: String) -> some View {
+        Text(title.uppercased())
+            .font(.system(size: 10, weight: .semibold))
+            .foregroundColor(.secondary)
+            .tracking(0.5)
+    }
+
+    private func slider(_ title: String, value: Binding<Double>, range: ClosedRange<Double>) -> some View {
+        HStack(spacing: 10) {
+            Text(title)
+                .font(.system(size: 11))
+                .frame(width: 58, alignment: .leading)
+            Slider(value: value, in: range)
+            Text("\(Int((value.wrappedValue / range.upperBound * 100).rounded()))%")
+                .font(.system(size: 10, design: .rounded))
+                .monospacedDigit()
+                .foregroundColor(.secondary)
+                .frame(width: 34, alignment: .trailing)
+        }
+    }
+
+    private var paddingBinding: Binding<Double> {
+        Binding(get: { state.background.paddingFraction },
+                set: { state.background.paddingFraction = $0 })
+    }
+    private var cornerBinding: Binding<Double> {
+        Binding(get: { state.background.cornerFraction },
+                set: { state.background.cornerFraction = $0 })
+    }
+    private var shadowBinding: Binding<Double> {
+        Binding(get: { state.background.shadowStrength },
+                set: { state.background.shadowStrength = $0 })
+    }
+    private var darkBinding: Binding<Bool> {
+        Binding(
+            get: { state.background.frame.isDark },
+            set: { isDark in
+                switch state.background.frame {
+                case .macOSLight, .macOSDark:
+                    state.background.frame = isDark ? .macOSDark : .macOSLight
+                case .browserLight, .browserDark:
+                    state.background.frame = isDark ? .browserDark : .browserLight
+                case .none:
+                    break
+                }
+            })
+    }
+}
+
+// MARK: - Swatch Button
+
+private struct SwatchButton<Content: View>: View {
+    let isSelected: Bool
+    let action: () -> Void
+    @ViewBuilder let content: () -> Content
+
+    var body: some View {
+        Button(action: action) {
+            content()
+                .frame(width: 30, height: 30)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 5)
+                        .stroke(Color.primary.opacity(0.15), lineWidth: 1)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 5)
+                        .stroke(Color.accentColor, lineWidth: isSelected ? 2.5 : 0)
+                )
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/Shotter/Sources/Annotations/BackgroundRenderer.swift
+++ b/Shotter/Sources/Annotations/BackgroundRenderer.swift
@@ -1,0 +1,223 @@
+import AppKit
+
+/// Shared compositing for the beautify "background" frame. The same routine
+/// drives the live canvas preview and the final export so they stay pixel-identical.
+///
+/// All drawing assumes a bottom-left origin CGContext in the same coordinate
+/// space as `layout` (view points for preview, output points for export).
+enum BackgroundRenderer {
+
+    /// Corners of a rect, in bottom-left coordinate space.
+    struct Corners: OptionSet {
+        let rawValue: Int
+        static let topLeft = Corners(rawValue: 1 << 0)
+        static let topRight = Corners(rawValue: 1 << 1)
+        static let bottomLeft = Corners(rawValue: 1 << 2)
+        static let bottomRight = Corners(rawValue: 1 << 3)
+        static let all: Corners = [.topLeft, .topRight, .bottomLeft, .bottomRight]
+        static let bottom: Corners = [.bottomLeft, .bottomRight]
+    }
+
+    /// Draws the background fill, drop shadow, and window chrome, then invokes
+    /// `drawScreenshot(contentRect)` with a rounded clip already applied so the
+    /// screenshot picks up the frame's corner treatment.
+    static func drawBeautified(
+        in ctx: CGContext,
+        layout: BeautifyLayout,
+        style: BackgroundStyle,
+        imageSize: CGSize,
+        drawScreenshot: (CGRect) -> Void
+    ) {
+        // 1) Background fill across the whole canvas.
+        switch style.kind {
+        case .none:
+            break // transparent — leave whatever is behind
+        case .solid:
+            ctx.saveGState()
+            ctx.setFillColor(style.solidColor.cgColor)
+            ctx.fill(layout.canvasRect)
+            ctx.restoreGState()
+        case .gradient:
+            drawGradient(style.gradient.colors, in: layout.canvasRect, context: ctx)
+        }
+
+        let radius = layout.cornerRadius
+        let windowRect = layout.windowRect
+        let hasFrame = style.frame != .none
+
+        // 2) Drop shadow — cast by an opaque rounded card behind the content.
+        if style.shadowStrength > 0.001 {
+            let minSide = min(windowRect.width, windowRect.height)
+            let strength = CGFloat(style.shadowStrength)
+            let blur = minSide * 0.06 * (0.4 + strength)
+            let dy = -minSide * 0.03 * strength
+            let alpha = min(0.6, 0.12 + 0.5 * strength)
+
+            ctx.saveGState()
+            ctx.setShadow(offset: CGSize(width: 0, height: dy), blur: blur,
+                          color: NSColor.black.withAlphaComponent(alpha).cgColor)
+            ctx.addPath(roundedPath(windowRect, radius: radius, corners: .all))
+            ctx.setFillColor((hasFrame ? style.frame.barColor : NSColor.white).cgColor)
+            ctx.fillPath()
+            ctx.restoreGState()
+        }
+
+        // 3) Window chrome (title bar + controls) for framed styles.
+        if hasFrame {
+            drawTitleBar(in: ctx, layout: layout, style: style, radius: radius)
+        }
+
+        // 4) Screenshot, clipped to the window's rounded shape.
+        ctx.saveGState()
+        ctx.addPath(roundedPath(windowRect, radius: radius, corners: .all))
+        ctx.clip()
+        // Intersect with the content strip so the title bar area stays visible.
+        ctx.clip(to: layout.contentRect)
+        drawScreenshot(layout.contentRect)
+        ctx.restoreGState()
+    }
+
+    // MARK: - Title bar
+
+    private static func drawTitleBar(in ctx: CGContext, layout: BeautifyLayout,
+                                     style: BackgroundStyle, radius: CGFloat) {
+        let windowRect = layout.windowRect
+        let barHeight = layout.titleBarHeight
+        guard barHeight > 0 else { return }
+
+        let barRect = CGRect(x: windowRect.minX, y: windowRect.maxY - barHeight,
+                             width: windowRect.width, height: barHeight)
+
+        // Fill the bar, keeping the window's rounded top corners.
+        ctx.saveGState()
+        ctx.addPath(roundedPath(windowRect, radius: radius, corners: .all))
+        ctx.clip()
+        ctx.clip(to: barRect)
+        ctx.setFillColor(style.frame.barColor.cgColor)
+        ctx.fill(barRect)
+        // Subtle separator under the bar.
+        ctx.setFillColor(NSColor.black.withAlphaComponent(style.frame.isDark ? 0.25 : 0.08).cgColor)
+        ctx.fill(CGRect(x: barRect.minX, y: barRect.minY, width: barRect.width, height: max(0.5, barHeight * 0.02)))
+        ctx.restoreGState()
+
+        // Traffic-light controls.
+        let r = barHeight * 0.15
+        let cy = barRect.midY
+        var cx = barRect.minX + barHeight * 0.62
+        let dotColors = [NSColor(hex: "#FF5F57"), NSColor(hex: "#FEBC2E"), NSColor(hex: "#28C840")]
+        for color in dotColors {
+            ctx.setFillColor(color.cgColor)
+            ctx.fillEllipse(in: CGRect(x: cx - r, y: cy - r, width: r * 2, height: r * 2))
+            cx += r * 3.4
+        }
+
+        // Browser URL pill.
+        if style.frame.isBrowser {
+            let pillW = windowRect.width * 0.46
+            let pillH = barHeight * 0.44
+            let pillRect = CGRect(x: barRect.midX - pillW / 2, y: cy - pillH / 2,
+                                  width: pillW, height: pillH)
+            ctx.addPath(roundedPath(pillRect, radius: pillH / 2, corners: .all))
+            ctx.setFillColor((style.frame.isDark ? NSColor(hex: "#404044") : NSColor.white).cgColor)
+            ctx.fillPath()
+        }
+    }
+
+    // MARK: - Gradient
+
+    static func drawGradient(_ colors: [NSColor], in rect: CGRect, context ctx: CGContext) {
+        guard !colors.isEmpty else { return }
+        let cgColors = colors.compactMap { $0.usingColorSpace(.sRGB)?.cgColor } as CFArray
+        let locations: [CGFloat] = colors.count == 1
+            ? [0]
+            : (0..<colors.count).map { CGFloat($0) / CGFloat(colors.count - 1) }
+
+        guard let gradient = CGGradient(colorsSpace: CGColorSpace(name: CGColorSpace.sRGB),
+                                        colors: cgColors, locations: locations) else { return }
+        ctx.saveGState()
+        ctx.clip(to: rect)
+        // Diagonal top-left → bottom-right.
+        let start = CGPoint(x: rect.minX, y: rect.maxY)
+        let end = CGPoint(x: rect.maxX, y: rect.minY)
+        ctx.drawLinearGradient(gradient, start: start, end: end,
+                               options: [.drawsBeforeStartLocation, .drawsAfterEndLocation])
+        ctx.restoreGState()
+    }
+
+    // MARK: - Rounded path
+
+    static func roundedPath(_ rect: CGRect, radius: CGFloat, corners: Corners) -> CGPath {
+        let path = CGMutablePath()
+        let r = max(0, min(radius, min(rect.width, rect.height) / 2))
+        if r <= 0 {
+            path.addRect(rect)
+            return path
+        }
+
+        let tl = corners.contains(.topLeft) ? r : 0
+        let tr = corners.contains(.topRight) ? r : 0
+        let bl = corners.contains(.bottomLeft) ? r : 0
+        let br = corners.contains(.bottomRight) ? r : 0
+
+        // Bottom-left origin. Start at bottom edge, go clockwise.
+        path.move(to: CGPoint(x: rect.minX + bl, y: rect.minY))
+        path.addLine(to: CGPoint(x: rect.maxX - br, y: rect.minY))
+        path.addArc(tangent1End: CGPoint(x: rect.maxX, y: rect.minY),
+                    tangent2End: CGPoint(x: rect.maxX, y: rect.minY + br), radius: br)
+        path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY - tr))
+        path.addArc(tangent1End: CGPoint(x: rect.maxX, y: rect.maxY),
+                    tangent2End: CGPoint(x: rect.maxX - tr, y: rect.maxY), radius: tr)
+        path.addLine(to: CGPoint(x: rect.minX + tl, y: rect.maxY))
+        path.addArc(tangent1End: CGPoint(x: rect.minX, y: rect.maxY),
+                    tangent2End: CGPoint(x: rect.minX, y: rect.maxY - tl), radius: tl)
+        path.addLine(to: CGPoint(x: rect.minX, y: rect.minY + bl))
+        path.addArc(tangent1End: CGPoint(x: rect.minX, y: rect.minY),
+                    tangent2End: CGPoint(x: rect.minX + bl, y: rect.minY), radius: bl)
+        path.closeSubpath()
+        return path
+    }
+
+    // MARK: - Export
+
+    /// Composites the beautify frame around an already-annotated screenshot,
+    /// rendered at the screenshot's native pixel density. Returns the annotated
+    /// screenshot unchanged when the style is inactive.
+    static func renderBeautified(annotated: NSImage, imageSize: CGSize, style: BackgroundStyle) -> NSImage {
+        guard style.isActive,
+              let annotatedCG = annotated.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
+            return annotated
+        }
+
+        // Pixel density of the source (Retina screenshots are typically 2x).
+        let px = max(1, CGFloat(annotatedCG.width) / max(imageSize.width, 1))
+
+        // Compute the canvas in point space (viewSize == canvasSize → scale 1),
+        // then scale the whole context by px for native-resolution output.
+        let refDim = max(imageSize.width, imageSize.height)
+        let padPts = CGFloat(style.paddingFraction) * refDim
+        let titlePts = style.titleBarHeight(imageWidth: imageSize.width)
+        let canvasPts = CGSize(width: imageSize.width + 2 * padPts,
+                               height: imageSize.height + titlePts + 2 * padPts)
+
+        let pixelW = Int((canvasPts.width * px).rounded())
+        let pixelH = Int((canvasPts.height * px).rounded())
+        guard pixelW > 0, pixelH > 0,
+              let ctx = CGContext(data: nil, width: pixelW, height: pixelH,
+                                  bitsPerComponent: 8, bytesPerRow: 0,
+                                  space: CGColorSpace(name: CGColorSpace.sRGB)!,
+                                  bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue) else {
+            return annotated
+        }
+
+        ctx.scaleBy(x: px, y: px)
+        ctx.interpolationQuality = .high
+
+        let layout = beautifyLayout(viewSize: canvasPts, imageSize: imageSize, style: style)
+        drawBeautified(in: ctx, layout: layout, style: style, imageSize: imageSize) { contentRect in
+            ctx.draw(annotatedCG, in: contentRect)
+        }
+
+        guard let outCG = ctx.makeImage() else { return annotated }
+        return NSImage(cgImage: outCG, size: canvasPts)
+    }
+}

--- a/Shotter/Sources/Annotations/BackgroundStyle.swift
+++ b/Shotter/Sources/Annotations/BackgroundStyle.swift
@@ -1,0 +1,219 @@
+import AppKit
+
+// MARK: - Background Kind
+
+/// The fill behind the screenshot when beautify is active.
+enum BackgroundKind: String, Codable {
+    case none      // transparent (no fill) — useful with a frame/shadow for overlays
+    case solid
+    case gradient
+}
+
+/// Optional window chrome drawn around the screenshot.
+enum FrameStyle: String, Codable {
+    case none
+    case macOSLight
+    case macOSDark
+    case browserLight
+    case browserDark
+
+    var isMacOS: Bool { self == .macOSLight || self == .macOSDark }
+    var isBrowser: Bool { self == .browserLight || self == .browserDark }
+    var isDark: Bool { self == .macOSDark || self == .browserDark }
+
+    /// Title bar height in screenshot-point space (0 when no frame).
+    func titleBarHeight(imageWidth: CGFloat) -> CGFloat {
+        switch self {
+        case .none:
+            return 0
+        case .macOSLight, .macOSDark:
+            return max(26, imageWidth * 0.028)
+        case .browserLight, .browserDark:
+            return max(40, imageWidth * 0.05)
+        }
+    }
+
+    var barColor: NSColor {
+        isDark ? NSColor(hex: "#2B2B2E") : NSColor(hex: "#EDEDED")
+    }
+}
+
+// MARK: - Gradient Presets
+
+struct GradientPreset: Identifiable, Equatable {
+    let id: String
+    let name: String
+    let hexStops: [String]
+
+    var colors: [NSColor] { hexStops.map { NSColor(hex: $0) } }
+
+    static let all: [GradientPreset] = [
+        GradientPreset(id: "sunset", name: "Sunset", hexStops: ["#FF7E5F", "#FEB47B"]),
+        GradientPreset(id: "grape", name: "Grape", hexStops: ["#667EEA", "#764BA2"]),
+        GradientPreset(id: "ocean", name: "Ocean", hexStops: ["#2193B0", "#6DD5ED"]),
+        GradientPreset(id: "mint", name: "Mint", hexStops: ["#43E97B", "#38F9D7"]),
+        GradientPreset(id: "peach", name: "Peach", hexStops: ["#FFD3A5", "#FD6585"]),
+        GradientPreset(id: "sky", name: "Sky", hexStops: ["#A1C4FD", "#C2E9FB"]),
+        GradientPreset(id: "rose", name: "Rose", hexStops: ["#F4C4F3", "#FC67FA"]),
+        GradientPreset(id: "slate", name: "Slate", hexStops: ["#3A3D40", "#181A1B"]),
+    ]
+
+    static func preset(id: String) -> GradientPreset {
+        all.first(where: { $0.id == id }) ?? all[0]
+    }
+}
+
+/// Curated solid background colors (hex).
+enum SolidPreset {
+    static let hexes: [String] = [
+        "#FFFFFF", "#F2F2F7", "#D9DDE3", "#1C1C1E", "#000000",
+        "#2563EB", "#059669", "#DC2626", "#7C3AED", "#EA580C",
+    ]
+}
+
+// MARK: - Background Style
+
+/// Global "beautify" style for the editor — a presentation frame composited
+/// around the annotated screenshot. All stored fields are primitives so the
+/// struct is trivially Codable for persistence.
+struct BackgroundStyle: Codable, Equatable {
+    var kind: BackgroundKind = .none
+    var solidHex: String = "#F2F2F7"
+    var gradientID: String = "sunset"
+    /// Padding as a fraction of the screenshot's larger dimension (0…0.22).
+    var paddingFraction: Double = 0.07
+    /// Corner radius as a fraction of the screenshot's smaller dimension (0…0.08).
+    var cornerFraction: Double = 0.022
+    /// Drop-shadow strength (0 = off … 1 = strong).
+    var shadowStrength: Double = 0.35
+    var frame: FrameStyle = .none
+
+    var solidColor: NSColor { NSColor(hex: solidHex) }
+    var gradient: GradientPreset { GradientPreset.preset(id: gradientID) }
+
+    /// Whether beautify deviates from the raw screenshot at all.
+    var isActive: Bool {
+        kind != .none || paddingFraction > 0.001 || frame != .none || shadowStrength > 0.001
+    }
+
+    /// The default, inactive style — identical output to a raw screenshot.
+    static let disabled = BackgroundStyle(
+        kind: .none, paddingFraction: 0, cornerFraction: 0, shadowStrength: 0, frame: .none
+    )
+
+    func titleBarHeight(imageWidth: CGFloat) -> CGFloat {
+        isActive ? frame.titleBarHeight(imageWidth: imageWidth) : 0
+    }
+}
+
+// MARK: - Persistence
+
+/// Remembers the last-used beautify style across captures (like CleanShot).
+enum BackgroundStore {
+    private static let key = "annotationBackgroundStyle"
+
+    static func load() -> BackgroundStyle {
+        guard let data = UserDefaults.standard.data(forKey: key),
+              let style = try? JSONDecoder().decode(BackgroundStyle.self, from: data) else {
+            return .disabled
+        }
+        return style
+    }
+
+    static func save(_ style: BackgroundStyle) {
+        if let data = try? JSONEncoder().encode(style) {
+            UserDefaults.standard.set(data, forKey: key)
+        }
+    }
+}
+
+// MARK: - Layout
+
+/// Resolved geometry for one beautify render, in the target coordinate space
+/// (view points for the live canvas, or output points for export).
+struct BeautifyLayout {
+    let canvasRect: CGRect   // full beautified area (background fill)
+    let windowRect: CGRect   // the card (screenshot + title bar) — shadow + rounding
+    let contentRect: CGRect  // the screenshot area (annotation coordinate anchor)
+    let scale: CGFloat       // contentRect.width / imageSize.width
+    let cornerRadius: CGFloat
+    let titleBarHeight: CGFloat
+}
+
+/// Computes beautify geometry that aspect-fits the whole composited canvas into
+/// `viewSize`. When the style is inactive this degenerates to a plain
+/// aspect-fit of the screenshot (identical to `annotationImageRect`).
+func beautifyLayout(viewSize: CGSize, imageSize: CGSize, style: BackgroundStyle) -> BeautifyLayout {
+    guard imageSize.width > 0, imageSize.height > 0,
+          viewSize.width > 0, viewSize.height > 0 else {
+        return BeautifyLayout(canvasRect: .zero, windowRect: .zero, contentRect: .zero,
+                              scale: 1, cornerRadius: 0, titleBarHeight: 0)
+    }
+
+    let active = style.isActive
+    let refDim = max(imageSize.width, imageSize.height)
+    let padPts = active ? CGFloat(style.paddingFraction) * refDim : 0
+    let titlePts = style.titleBarHeight(imageWidth: imageSize.width)
+
+    let canvasW = imageSize.width + 2 * padPts
+    let canvasH = imageSize.height + titlePts + 2 * padPts
+
+    let s = min(viewSize.width / canvasW, viewSize.height / canvasH)
+    let frameW = canvasW * s
+    let frameH = canvasH * s
+    let ox = (viewSize.width - frameW) / 2
+    let oy = (viewSize.height - frameH) / 2
+    let pad = padPts * s
+
+    let canvasRect = CGRect(x: ox, y: oy, width: frameW, height: frameH)
+    let contentRect = CGRect(x: ox + pad, y: oy + pad,
+                             width: imageSize.width * s, height: imageSize.height * s)
+    let windowRect = CGRect(x: ox + pad, y: oy + pad,
+                            width: imageSize.width * s,
+                            height: (imageSize.height + titlePts) * s)
+    let corner = active ? CGFloat(style.cornerFraction) * min(imageSize.width, imageSize.height) * s : 0
+
+    return BeautifyLayout(
+        canvasRect: canvasRect,
+        windowRect: windowRect,
+        contentRect: contentRect,
+        scale: s,
+        cornerRadius: corner,
+        titleBarHeight: titlePts * s
+    )
+}
+
+// MARK: - Hex Color
+
+extension NSColor {
+    /// Creates a color from a `#RRGGBB` or `#RRGGBBAA` hex string. Falls back to
+    /// gray on malformed input.
+    convenience init(hex: String) {
+        var s = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        if s.hasPrefix("#") { s.removeFirst() }
+        var value: UInt64 = 0
+        Scanner(string: s).scanHexInt64(&value)
+
+        let r, g, b, a: CGFloat
+        if s.count == 8 {
+            r = CGFloat((value >> 24) & 0xFF) / 255
+            g = CGFloat((value >> 16) & 0xFF) / 255
+            b = CGFloat((value >> 8) & 0xFF) / 255
+            a = CGFloat(value & 0xFF) / 255
+        } else {
+            r = CGFloat((value >> 16) & 0xFF) / 255
+            g = CGFloat((value >> 8) & 0xFF) / 255
+            b = CGFloat(value & 0xFF) / 255
+            a = 1
+        }
+        self.init(srgbRed: r, green: g, blue: b, alpha: a)
+    }
+
+    var hexString: String {
+        guard let c = usingColorSpace(.sRGB) else { return "#000000" }
+        let r = Int((c.redComponent * 255).rounded())
+        let g = Int((c.greenComponent * 255).rounded())
+        let b = Int((c.blueComponent * 255).rounded())
+        return String(format: "#%02X%02X%02X", r, g, b)
+    }
+}


### PR DESCRIPTION
Backgrounds & frames for the annotation editor: gradient/solid backgrounds, padding, rounded corners, drop shadow, and optional macOS/browser window frames.

Backgrounds are a presentation frame, not a tool — `imageRectInView()` returns the screenshot content-rect inside the padded frame, so all existing annotation/crop/blur math is untouched. Inactive style renders pixel-identical to the raw screenshot.

Supersedes #74 (auto-closed when its base branch was deleted during the #72 merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)